### PR TITLE
feat: provide first version of output task callback

### DIFF
--- a/armonik-client/src/main/java/fr/aneo/armonik/client/ArmoniKClientBuilder.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/ArmoniKClientBuilder.java
@@ -17,6 +17,7 @@ package fr.aneo.armonik.client;
 
 import fr.aneo.armonik.client.payload.JsonPayloadSerializer;
 import fr.aneo.armonik.client.task.TaskConfiguration;
+import fr.aneo.armonik.client.blob.event.BlobCompletionListener;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -49,6 +50,7 @@ public class ArmoniKClientBuilder {
   private final Set<String> partitionIds = new HashSet<>();
   private TaskConfiguration taskConfiguration = null;//defaultConfiguration();
   private ArmoniKConnectionConfig connectionConfiguration;
+  private BlobCompletionListener blobCompletionListener;
 
   /**
    * Sets the default task configuration applied to the client's session.
@@ -96,6 +98,29 @@ public class ArmoniKClientBuilder {
   }
 
   /**
+   * Registers a listener to receive callbacks when task outputs complete.
+   * <p>
+   * The provided {@link BlobCompletionListener} will be invoked for each task output produced
+   * by tasks submitted through the constructed {@link ArmoniKClient}. The listener is notified
+   * on successful completion as well as on failures.
+   *
+   * <p>
+   * This listener is optional. If not set, task outputs can still be retrieved manually,
+   * but no automatic callbacks will be triggered.
+   * </p>
+   *
+   * @param blobCompletionListener the listener to notify for task output events; may be {@code null}
+   *                               to disable callbacks
+   * @return this builder
+   * @see BlobCompletionListener
+   * @see ArmoniKClient
+   */
+  public ArmoniKClientBuilder withTaskOutputListener(BlobCompletionListener blobCompletionListener) {
+    this.blobCompletionListener = blobCompletionListener;
+    return this;
+  }
+
+  /**
    * Builds a new {@link ArmoniKClient} instance with the configured settings and opens a session.
    *
    * @return a configured client instance
@@ -109,6 +134,7 @@ public class ArmoniKClientBuilder {
       partitionIds,
       taskConfiguration,
       new JsonPayloadSerializer(),
-      services);
+      services,
+      blobCompletionListener);
   }
 }

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/DefaultServices.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/DefaultServices.java
@@ -17,10 +17,12 @@ package fr.aneo.armonik.client;
 
 import fr.aneo.armonik.client.blob.BlobService;
 import fr.aneo.armonik.client.blob.DefaultBlobService;
+import fr.aneo.armonik.client.blob.event.BlobCompletionEventWatcher;
 import fr.aneo.armonik.client.session.DefaultSessionService;
 import fr.aneo.armonik.client.session.SessionService;
 import fr.aneo.armonik.client.task.DefaultTaskService;
 import fr.aneo.armonik.client.task.TaskService;
+import fr.aneo.armonik.client.blob.event.DefaultBlobCompletionEventWatcher;
 import io.grpc.ManagedChannel;
 
 import static java.util.Objects.*;
@@ -32,6 +34,7 @@ final class DefaultServices implements Services {
   private final SessionService sessionService;
   private final BlobService blobService;
   private final TaskService taskService;
+  private final BlobCompletionEventWatcher blobCompletionEventWatcher;
 
   DefaultServices(ArmoniKConnectionConfig armoniKConnectionConfig) {
     requireNonNull(armoniKConnectionConfig, "connectionConfiguration must not be null");
@@ -40,6 +43,7 @@ final class DefaultServices implements Services {
     this.sessionService = new DefaultSessionService(channel);
     this.blobService = new DefaultBlobService(channel);
     this.taskService = new DefaultTaskService(channel);
+    this.blobCompletionEventWatcher = new DefaultBlobCompletionEventWatcher(channel, blobService);
   }
 
   @Override
@@ -55,6 +59,11 @@ final class DefaultServices implements Services {
   @Override
   public TaskService tasks() {
     return taskService;
+  }
+
+  @Override
+  public BlobCompletionEventWatcher blobCompletionEventWatcher() {
+    return blobCompletionEventWatcher;
   }
 
   private ManagedChannel buildChannel(ArmoniKConnectionConfig connectionConfiguration) {

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/Services.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/Services.java
@@ -16,12 +16,36 @@
 package fr.aneo.armonik.client;
 
 import fr.aneo.armonik.client.blob.BlobService;
+import fr.aneo.armonik.client.blob.event.BlobCompletionEventWatcher;
 import fr.aneo.armonik.client.session.SessionService;
 import fr.aneo.armonik.client.task.TaskService;
 
 /**
- * Container interface exposing the ArmoniK service facades.
+ * Facade interface providing access to all ArmoniK client service components.
+ * <p>
+ * The {@code Services} interface serves as the primary access point for advanced ArmoniK operations,
+ * exposing individual service facades that wrap the underlying gRPC communication with the ArmoniK
+ * Control Plane. This design enables both high-level convenience through {@link fr.aneo.armonik.client.ArmoniKClient}
+ * and fine-grained control for advanced use cases.
+ *
+ * <h2>Service Components</h2>
+ * <p>
+ * Each service component provides specialized functionality for different aspects of ArmoniK interaction:
+ * <ul>
+ *   <li><strong>{@link SessionService}:</strong> Session lifecycle management and configuration</li>
+ *   <li><strong>{@link BlobService}:</strong> Blob (data) upload, download, and metadata operations</li>
+ *   <li><strong>{@link TaskService}:</strong> Task submission and execution management</li>
+ *   <li><strong>{@link BlobCompletionEventWatcher}:</strong> Real-time event streaming for blob state changes</li>
+ * </ul>
+ *
+ * @see fr.aneo.armonik.client.ArmoniKClient#services()
+ * @see SessionService
+ * @see BlobService
+ * @see TaskService
+ * @see BlobCompletionEventWatcher
+ * @see fr.aneo.armonik.client.ArmoniKClient
  */
+
 public interface Services {
 
   SessionService sessions();
@@ -29,4 +53,6 @@ public interface Services {
   BlobService blobs();
 
   TaskService tasks();
+
+  BlobCompletionEventWatcher blobCompletionEventWatcher();
 }

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/BlobCompletionEventSubscriber.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/BlobCompletionEventSubscriber.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.blob.event;
+
+import fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventSubscriptionResponse;
+import fr.aneo.armonik.api.grpc.v1.results.ResultStatusOuterClass.ResultStatus;
+import fr.aneo.armonik.client.blob.BlobMetadata;
+import fr.aneo.armonik.client.blob.BlobService;
+import fr.aneo.armonik.client.session.SessionHandle;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static fr.aneo.armonik.client.blob.event.BlobCompletionListener.Blob;
+import static fr.aneo.armonik.client.blob.event.BlobCompletionListener.BlobError;
+
+/**
+ * Internal gRPC stream observer that processes blob completion events and manages listener notifications.
+ * <p>
+ * This class implements the {@link StreamObserver} contract to handle server-side streaming events
+ * from the ArmoniK Control Plane's Events API. It serves as the bridge between the raw gRPC event
+ * stream and the higher-level {@link BlobCompletionListener} interface, providing event filtering,
+ * state management, and automatic blob data retrieval.
+ *
+ * <h2>Architecture Role</h2>
+ * <p>
+ * The subscriber is a key component in the ArmoniK client's reactive event processing pipeline:
+ * <ol>
+ *   <li>{@link BlobCompletionEventWatcher} establishes the gRPC stream</li>
+ *   <li>{@code BlobCompletionEventSubscriber} processes incoming events</li>
+ *   <li>{@link BlobCompletionListener} receives filtered, processed notifications</li>
+ * </ol>
+ *
+ * <h2>Event Processing Flow</h2>
+ * <p>
+ * For each incoming event, the subscriber:
+ * <ul>
+ *   <li>Filters events to only those matching watched blob IDs</li>
+ *   <li>Processes COMPLETED events by automatically downloading blob data</li>
+ *   <li>Processes ABORTED events by notifying about failures</li>
+ *   <li>Tracks completion progress and signals when all blobs are terminal</li>
+ *   <li>Handles listener exceptions gracefully to prevent stream disruption</li>
+ * </ul>
+ *
+ * <h2>Error Handling and Resilience</h2>
+ * <p>
+ * The implementation includes comprehensive error handling:
+ * <ul>
+ *   <li>Listener exceptions are caught and logged to prevent stream termination</li>
+ *   <li>Blob download failures are reported as error events to the listener</li>
+ *   <li>Stream errors are logged and propagated to the completion future</li>
+ *   <li>Unknown or malformed events are safely ignored</li>
+ * </ul>
+ *
+ * <h2>Thread Safety</h2>
+ * <p>
+ * This class is designed to be thread-safe for concurrent event processing. All shared state
+ * is protected using concurrent data structures and atomic operations. Listener callbacks
+ * may be invoked from multiple threads and should handle concurrency appropriately.
+ * </p>
+ *
+ * <h2>Performance Characteristics</h2>
+ * <p>
+ * The subscriber is optimized for low latency and minimal memory overhead:
+ * <ul>
+ *   <li>Events are processed synchronously on the gRPC event loop thread</li>
+ *   <li>Blob downloads are initiated asynchronously to avoid blocking the event stream</li>
+ *   <li>Completed blobs are immediately removed from tracking to reduce memory usage</li>
+ *   <li>Listener exceptions are isolated to prevent cascading failures</li>
+ * </ul>
+ * </p>
+ *
+ * @see BlobCompletionEventWatcher
+ * @see BlobCompletionListener
+ * @see StreamObserver
+ * @see fr.aneo.armonik.client.blob.BlobService
+ */
+final class BlobCompletionEventSubscriber implements StreamObserver<EventSubscriptionResponse> {
+
+  private static final Logger log = LoggerFactory.getLogger(BlobCompletionEventSubscriber.class);
+
+  private final SessionHandle sessionHandle;
+  private final ConcurrentMap<UUID, BlobMetadata> pending;
+  private final AtomicInteger remaining;
+  private final CompletableFuture<Void> completion;
+  private final BlobService blobService;
+  private final BlobCompletionListener listener;
+
+  BlobCompletionEventSubscriber(SessionHandle sessionHandle,
+                                ConcurrentMap<UUID, BlobMetadata> pending,
+                                CompletableFuture<Void> completion,
+                                BlobService blobService,
+                                BlobCompletionListener listener) {
+    this.sessionHandle = sessionHandle;
+    this.pending = pending;
+    this.remaining = new AtomicInteger(pending.size());
+    this.completion = completion;
+    this.blobService = blobService;
+    this.listener = listener;
+  }
+
+  @Override
+  public void onNext(EventSubscriptionResponse resp) {
+    switch (resp.getUpdateCase()) {
+      case RESULT_STATUS_UPDATE ->
+        handleEvent(resp.getResultStatusUpdate().getResultId(), resp.getResultStatusUpdate().getStatus());
+      case NEW_RESULT -> handleEvent(resp.getNewResult().getResultId(), resp.getNewResult().getStatus());
+      case UPDATE_NOT_SET -> { /* ignore */ }
+    }
+
+    if (remaining.get() == 0 && !completion.isDone()) {
+      completion.complete(null);
+    }
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+    log.atError().addKeyValue("sessionId", sessionHandle.id().toString())
+       .addKeyValue("error", throwable.getClass().getSimpleName())
+       .setCause(throwable)
+       .log("Blob Event Stream failed");
+  }
+
+  @Override
+  public void onCompleted() {
+    if (remaining.get() == 0 && !completion.isDone()) {
+      completion.complete(null);
+    }
+  }
+
+  private void handleEvent(String idString, ResultStatus status) {
+    final var id = UUID.fromString(idString);
+    switch (status) {
+      case RESULT_STATUS_COMPLETED -> {
+        final var metadata = pending.remove(id);
+        if (metadata != null) {
+          handleCompleted(metadata);
+        }
+      }
+      case RESULT_STATUS_ABORTED -> {
+        final var metadata = pending.remove(id);
+        if (metadata != null) {
+          handleAborted(metadata);
+        }
+      }
+      default -> { /* ignore */ }
+    }
+  }
+
+  private void handleAborted(BlobMetadata metadata) {
+    try {
+      listener.onError(new BlobError(metadata, null)); //TODO define exception
+    } catch (Throwable throwable) {
+      log.atError().addKeyValue("sessionId", sessionHandle.id().toString())
+         .addKeyValue("metadata", metadata)
+         .addKeyValue("error", throwable.getClass().getSimpleName())
+         .setCause(throwable)
+         .log("BlobCompletionListener throws an Exception");
+    } finally {
+      if (remaining.decrementAndGet() == 0 && !completion.isDone()) {
+        completion.complete(null);
+      }
+    }
+  }
+
+  private void handleCompleted(BlobMetadata metadata) {
+    blobService.downloadBlob(sessionHandle, metadata.id())
+               .whenComplete((bytes, err) -> {
+                 try {
+                   if (err == null) {
+                     listener.onSuccess(new Blob(metadata, bytes));
+                   } else {
+                     listener.onError(new BlobError(metadata, err));
+                   }
+                 } catch (Throwable throwable) {
+                   log.atError().addKeyValue("sessionId", sessionHandle.id().toString())
+                      .addKeyValue("metadata", metadata)
+                      .addKeyValue("error", throwable.getClass().getSimpleName())
+                      .setCause(throwable)
+                      .log("BlobCompletionListener throws an Exception");
+                 } finally {
+                   if (remaining.decrementAndGet() == 0 && !completion.isDone()) {
+                     completion.complete(null);
+                   }
+                 }
+               });
+  }
+}

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/BlobCompletionEventWatcher.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/BlobCompletionEventWatcher.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.blob.event;
+
+import fr.aneo.armonik.client.blob.BlobHandle;
+import fr.aneo.armonik.client.session.SessionHandle;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+
+/**
+ * Service for monitoring blob completion events within an ArmoniK session.
+ * <p>
+ * The {@code BlobCompletionEventWatcher} provides asynchronous notification capabilities for tracking
+ * when blobs (particularly task outputs) reach terminal states in the ArmoniK cluster. This service
+ * establishes a server-side streaming connection to the ArmoniK Control Plane to receive real-time
+ * events about blob state changes.
+ *
+ * <h2>Event-Driven Workflow</h2>
+ * <p>
+ * In the ArmoniK distributed computing model, tasks produce outputs that become available asynchronously
+ * as workers complete their execution. Rather than polling for completion status, this watcher enables
+ * reactive programming patterns by streaming completion events directly from the server.
+ *
+ * <h2>Blob States and Events</h2>
+ * <p>
+ * Blobs can transition through various states during task execution:
+ * <ul>
+ *   <li><strong>PENDING:</strong> Blob declared but not yet produced</li>
+ *   <li><strong>COMPLETED:</strong> Blob successfully created and available for download</li>
+ *   <li><strong>ABORTED:</strong> Blob creation failed due to task failure or cancellation</li>
+ * </ul>
+ *
+ * <h2>Usage Patterns</h2>
+ * <pre>{@code
+ * // Watch for task output completion
+ * BlobCompletionEventWatcher watcher = services.blobCompletionEventWatcher();
+ *
+ * List<BlobHandle> outputHandles = Arrays.asList(taskHandle.outputs().values());
+ *
+ * CompletionStage<Void> watchResult = watcher.watch(
+ *     sessionHandle,
+ *     outputHandles,
+ *     new BlobCompletionListener() {
+ *         @Override
+ *         public void onBlobCompleted(Blob blob) {
+ *             // Download and process completed output
+ *             System.out.println("Output ready: " + blob.metadata.id());
+ *         }
+ *
+ *         @Override
+ *         public void onBlobFailed(Blob blob, Throwable error) {
+ *             // Handle failed output
+ *             System.err.println("Output failed: " + blob.metadata.id());
+ *         }
+ *     }
+ * );
+ *
+ * // The future completes when all watched blobs are terminal
+ * watchResult.thenRun(() -> System.out.println("All outputs completed or failed"));
+ * }</pre>
+ *
+ * @see BlobCompletionListener
+ * @see fr.aneo.armonik.client.blob.BlobHandle
+ * @see fr.aneo.armonik.client.session.SessionHandle
+ * @see fr.aneo.armonik.client.Services#blobCompletionEventWatcher()
+ */
+public interface BlobCompletionEventWatcher {
+
+  /**
+   * Starts watching the specified blob handles for completion events within the given session.
+   * <p>
+   * This method establishes a server-side streaming connection to the ArmoniK Control Plane
+   * and monitors the provided blob handles for state transitions. The {@link BlobCompletionListener}
+   * receives callbacks as blobs complete successfully or fail.
+   *
+   * <p>
+   * The method returns immediately with a {@link CompletionStage} that represents the overall
+   * watching operation. This stage completes successfully when all watched blobs reach terminal
+   * states (either COMPLETED or ABORTED), or completes exceptionally if the streaming connection
+   * fails or is interrupted.
+   *
+   * <p>
+   * Events are delivered in the order they occur on the server, but completion notifications
+   * for different blobs may arrive in any order depending on task execution timing. The listener
+   * callbacks are invoked asynchronously and should handle concurrent access appropriately.
+   *
+   * @param sessionHandle the session context that owns the blobs being watched; must not be {@code null}
+   * @param blobHandles   list of blob handles to monitor for completion; must not be {@code null},
+   *                      but may be empty (in which case the operation completes immediately)
+   * @param listener      callback interface for receiving completion events; must not be {@code null}
+   * @return a {@link CompletionStage} that completes when all watched blobs reach terminal states,
+   *         or completes exceptionally if the watching operation fails
+   * @throws NullPointerException if any parameter is {@code null}
+   * @throws IllegalArgumentException if any blob handle belongs to a different session than {@code sessionHandle}
+   * @see BlobCompletionListener#onSuccess(BlobCompletionListener.Blob)
+   * @see BlobCompletionListener#onError(BlobCompletionListener.BlobError)
+   */
+
+  CompletionStage<Void> watch(SessionHandle sessionHandle,
+                              List<BlobHandle> blobHandles,
+                              BlobCompletionListener listener);
+}

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/BlobCompletionListener.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/BlobCompletionListener.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.blob.event;
+
+import fr.aneo.armonik.client.blob.BlobMetadata;
+
+/**
+ * Callback interface for receiving asynchronous notifications about blob completion events.
+ * <p>
+ * The {@code BlobCompletionListener} provides a reactive programming model for handling blob
+ * state changes within the ArmoniK distributed computing platform. This interface is primarily
+ * used to receive notifications when task outputs become available for download or when blob
+ * operations fail.
+ *
+ * <h2>Event-Driven Task Processing</h2>
+ * <p>
+ * In ArmoniK's asynchronous execution model, tasks run on remote workers and produce outputs
+ * at unpredictable times. Rather than polling for completion, applications can register a
+ * {@code BlobCompletionListener} to receive immediate notifications when:
+ * <ul>
+ *   <li>Task outputs are successfully created and available for download</li>
+ *   <li>Task execution fails, causing expected outputs to become unavailable</li>
+ *   <li>Network or storage issues prevent blob operations from completing</li>
+ * </ul>
+ *
+ *
+ * <p>
+ * Implementations of this interface must be thread-safe, as callback methods may be invoked
+ * concurrently from multiple threads within the ArmoniK client's event processing system.
+ * The callbacks are typically invoked on gRPC event loop threads or executor service threads,
+ * not on the calling application's main thread.
+ * </p>
+ *
+ * <h2>Exception Handling</h2>
+ * <p>
+ * Implementations should handle exceptions gracefully within callback methods. Uncaught
+ * exceptions thrown from callback methods are logged but do not interrupt the event stream
+ * or affect the processing of other events. However, they may prevent proper resource
+ * cleanup or error reporting for the specific event that triggered the exception.
+ * </p>
+ *
+ * <h2>Performance Considerations</h2>
+ * <p>
+ * Callback methods should complete quickly to avoid blocking the event processing pipeline.
+ * For CPU-intensive or I/O-bound operations, consider offloading work to a separate thread
+ * or executor service:
+ * </p>
+ * <pre>{@code
+ * private final Executor processingExecutor = Executors.newCachedThreadPool();
+ *
+ * @Override
+ * public void onBlobCompleted(Blob blob) {
+ *     processingExecutor.execute(() -> {
+ *         // Perform heavy processing off the event thread
+ *         processLargeResult(blob.data());
+ *     });
+ * }
+ * }</pre>
+ *
+ * @see BlobCompletionEventWatcher
+ * @see Blob
+ * @see fr.aneo.armonik.client.ArmoniKClientBuilder#withTaskOutputListener(BlobCompletionListener)
+ * @see fr.aneo.armonik.client.blob.BlobHandle
+ * @see fr.aneo.armonik.client.task.TaskHandle
+ */
+public interface BlobCompletionListener {
+
+  void onSuccess(Blob blob);
+
+  void onError(BlobError blobError);
+
+  record Blob(BlobMetadata metadata, byte[] data) {
+  }
+
+  record BlobError(BlobMetadata metadata, Throwable cause) {
+  }
+}

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/BlobEventCompletionBatcher.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/BlobEventCompletionBatcher.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.blob.event;
+
+import fr.aneo.armonik.client.blob.BlobHandle;
+import fr.aneo.armonik.client.session.SessionHandle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static fr.aneo.armonik.client.util.Futures.allOf;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+/**
+ * Basic batching utility for managing multiple blob completion watching operations.
+ * <p>
+ * This class provides a simple mechanism to coordinate multiple concurrent blob watching
+ * operations through a single {@link BlobCompletionEventWatcher} instance. It allows
+ * enqueueing multiple watch requests and waiting for their collective completion.
+ *
+ * <p>
+ * <strong>Note:</strong> This is a basic implementation that will be fully reworked in
+ * future versions. The current design is intended for simple use cases and may not be
+ * suitable for high-throughput or complex batching scenarios.
+ *
+ * @see BlobCompletionEventWatcher
+ * @see BlobCompletionListener
+ */
+
+public class BlobEventCompletionBatcher {
+
+  private final BlobCompletionEventWatcher watcher;
+  private final BlobCompletionListener listener;
+
+  private final Queue<CompletionStage<Void>> inFlightStages = new ConcurrentLinkedQueue<>();
+
+  /**
+   * Creates a new batcher that will use the specified watcher and listener for all operations.
+   *
+   * @param watcher  the event watcher to use for blob monitoring; must not be {@code null}
+   * @param listener the listener to receive completion events; must not be {@code null}
+   * @throws NullPointerException if either parameter is {@code null}
+   */
+  public BlobEventCompletionBatcher(BlobCompletionEventWatcher watcher, BlobCompletionListener listener) {
+    this.watcher = watcher;
+    this.listener = listener;
+  }
+
+  /**
+   * Enqueues a new blob watching operation to be tracked by this batcher.
+   *
+   * @param sessionHandle the session context for the blobs to watch; must not be {@code null}
+   * @param blobHandles   the blob handles to monitor; must not be {@code null}
+   * @throws NullPointerException if any parameter is {@code null}
+   */
+  public void enqueue(SessionHandle sessionHandle, List<BlobHandle> blobHandles) {
+    inFlightStages.add(watcher.watch(sessionHandle, blobHandles, listener));
+  }
+
+  /**
+   * Returns a completion stage that completes when all currently enqueued operations finish.
+   * <p>
+   * This method takes a snapshot of all in-flight operations at the time of invocation
+   * and returns a stage that completes when all of them reach terminal states.
+   * Operations enqueued after calling this method are not included in the returned stage.
+   * </p>
+   *
+   * @return a completion stage that completes when all current operations finish,
+   *         or a completed stage if no operations are in progress
+   */
+  public CompletionStage<Void> waitUntilFinished() {
+    var snapshot = new ArrayList<>(inFlightStages);
+    if (snapshot.isEmpty()) return completedFuture(null);
+
+    return allOf(snapshot).thenApply(v -> null);
+  }
+}

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/DefaultBlobCompletionEventWatcher.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/blob/event/DefaultBlobCompletionEventWatcher.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.blob.event;
+
+import fr.aneo.armonik.api.grpc.v1.FiltersCommon.FilterString;
+import fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventSubscriptionRequest;
+import fr.aneo.armonik.api.grpc.v1.events.EventsGrpc;
+import fr.aneo.armonik.api.grpc.v1.results.ResultsFields.ResultField;
+import fr.aneo.armonik.api.grpc.v1.results.ResultsFields.ResultRawField;
+import fr.aneo.armonik.api.grpc.v1.results.ResultsFilters.FilterField;
+import fr.aneo.armonik.client.blob.BlobHandle;
+import fr.aneo.armonik.client.blob.BlobMetadata;
+import fr.aneo.armonik.client.blob.BlobService;
+import fr.aneo.armonik.client.session.SessionHandle;
+import fr.aneo.armonik.client.util.Futures;
+import io.grpc.ManagedChannel;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static fr.aneo.armonik.api.grpc.v1.FiltersCommon.FilterStringOperator.FILTER_STRING_OPERATOR_EQUAL;
+import static fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventsEnum.EVENTS_ENUM_NEW_RESULT;
+import static fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventsEnum.EVENTS_ENUM_RESULT_STATUS_UPDATE;
+import static fr.aneo.armonik.api.grpc.v1.results.ResultsFields.ResultRawEnumField.RESULT_RAW_ENUM_FIELD_RESULT_ID;
+import static fr.aneo.armonik.api.grpc.v1.results.ResultsFilters.Filters;
+import static fr.aneo.armonik.api.grpc.v1.results.ResultsFilters.FiltersAnd;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+public final class DefaultBlobCompletionEventWatcher implements BlobCompletionEventWatcher {
+
+  private final EventsGrpc.EventsStub eventsStub;
+  private final BlobService blobService;
+
+  public DefaultBlobCompletionEventWatcher(ManagedChannel channel, BlobService blobService) {
+    this.eventsStub = EventsGrpc.newStub(channel);
+    this.blobService = blobService;
+  }
+
+  @Override
+  public CompletionStage<Void> watch(SessionHandle sessionHandle,
+                                     List<BlobHandle> blobHandles,
+                                     BlobCompletionListener listener) {
+    requireNonNull(sessionHandle, "sessionHandle must not be null");
+    requireNonNull(blobHandles, "blobHandles must not be null");
+    requireNonNull(listener, "listener must not be null");
+
+    CompletableFuture<Void> completion = new CompletableFuture<>();
+
+    Futures.allOf(blobHandles.stream().map(BlobHandle::metadata).toList())
+           .thenAccept(metadataList -> {
+             var metadataById = new ConcurrentHashMap<>(metadataList.stream().collect(toMap(BlobMetadata::id, identity())));
+
+             if (metadataById.isEmpty()) {
+               completion.complete(null);
+             } else {
+               var request = createEventSubscriptionRequest(sessionHandle.id(), metadataList);
+               eventsStub.getEvents(
+                 request,
+                 new BlobCompletionEventSubscriber(sessionHandle, metadataById, completion, blobService, listener)
+               );
+             }
+           })
+           .exceptionally(ex -> {
+             completion.completeExceptionally(ex);
+             return null;
+           });
+
+    return completion;
+  }
+
+  private static EventSubscriptionRequest createEventSubscriptionRequest(UUID sessionId, List<BlobMetadata> metadata) {
+    var filterOperator = FilterString.newBuilder()
+                                     .setOperator(FILTER_STRING_OPERATOR_EQUAL);
+    var resultField = ResultField.newBuilder()
+                                 .setResultRawField(ResultRawField.newBuilder()
+                                                                  .setField(RESULT_RAW_ENUM_FIELD_RESULT_ID));
+    var filterFieldBuilder = FilterField.newBuilder()
+                                        .setField(resultField)
+                                        .setFilterString(filterOperator);
+
+    var resultFiltersBuilder = Filters.newBuilder();
+
+    metadata.forEach(metadatum -> {
+      filterFieldBuilder.setFilterString(FilterString.newBuilder().setValue(metadatum.id().toString()));
+      resultFiltersBuilder.addOr(FiltersAnd.newBuilder().addAnd(filterFieldBuilder));
+    });
+
+    return EventSubscriptionRequest.newBuilder()
+                                   .setResultsFilters(resultFiltersBuilder.build())
+                                   .addReturnedEvents(EVENTS_ENUM_RESULT_STATUS_UPDATE)
+                                   .addReturnedEvents(EVENTS_ENUM_NEW_RESULT)
+                                   .setSessionId(sessionId.toString())
+                                   .build();
+  }
+}

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/util/Futures.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/util/Futures.java
@@ -18,6 +18,7 @@ package fr.aneo.armonik.client.util;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +92,7 @@ public final class Futures {
    * @return a stage that yields a list of results or fails if any input stage fails
    * @throws NullPointerException if {@code stages} is null
    */
-  public static <T> CompletionStage<List<T>> allOf(List<CompletionStage<T>> stages) {
+  public static <T> CompletionStage<List<T>> allOf(Collection<CompletionStage<T>> stages) {
     if (stages.isEmpty()) return completedFuture(List.of());
 
     var futures = stages.stream().map(CompletionStage::toCompletableFuture).toList();

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/ArmoniKClientTest.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/ArmoniKClientTest.java
@@ -57,11 +57,11 @@ class ArmoniKClientTest {
     when(services.sessions().createSession(any(), any())).thenReturn(session);
 
     // When
-    var client = new ArmoniKClient(Set.of("partition1"), taskConfiguration, services);
+    var client = new ArmoniKClient(Set.of("partition1"), taskConfiguration, services, null);
 
     // Then
     verify(services.sessions()).createSession(partitionIds, taskConfiguration);
-    assertThat(client.sessionHandle).isEqualTo(session);
+    assertThat(client.sessionHandle()).isEqualTo(session);
   }
 
   @Test
@@ -87,7 +87,7 @@ class ArmoniKClientTest {
     when(payloadSerializer.serialize(anyMap(), anyMap())).thenReturn(payloadDefinition);
     when(services.sessions().createSession(any(), any())).thenReturn(session);
 
-    var client = new ArmoniKClient(Set.of("partition1"), defaultConfiguration(), payloadSerializer, services);
+    var client = new ArmoniKClient(Set.of("partition1"), defaultConfiguration(), payloadSerializer, services, null);
 
     // When
     client.submitTask(taskDefinition);

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/blob/DefaultBlobServiceTest.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/blob/DefaultBlobServiceTest.java
@@ -15,6 +15,7 @@
  */
 package fr.aneo.armonik.client.blob;
 
+import fr.aneo.armonik.client.mocks.ResultsGrpcMock;
 import fr.aneo.armonik.client.task.TaskDefinition;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -43,15 +44,15 @@ class DefaultBlobServiceTest {
   public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
   private DefaultBlobService blobService;
-  private ResultsServiceMock resultsServiceMock;
+  private ResultsGrpcMock resultsGrpcMock;
 
   @BeforeEach
   void setUp() throws IOException {
-    resultsServiceMock = new ResultsServiceMock();
+    resultsGrpcMock = new ResultsGrpcMock();
     String serverName = InProcessServerBuilder.generateName();
     grpcCleanup.register(InProcessServerBuilder.forName(serverName)
                                                .directExecutor()
-                                               .addService(resultsServiceMock)
+                                               .addService(resultsGrpcMock)
                                                .build()
                                                .start());
 
@@ -99,9 +100,9 @@ class DefaultBlobServiceTest {
     blobService.uploadBlobData(blobHandle, BlobDefinition.from("Hello".getBytes())).toCompletableFuture().join();
 
     // Then
-    assertThat(resultsServiceMock.sessionId).isEqualTo(blobHandle.sessionHandle().id().toString());
-    assertThat(resultsServiceMock.blobId).isEqualTo(blobHandle.metadata().toCompletableFuture().join().id().toString());
-    assertThat(resultsServiceMock.receivedData.toByteArray()).asString().isEqualTo("Hello");
+    assertThat(resultsGrpcMock.sessionId).isEqualTo(blobHandle.sessionHandle().id().toString());
+    assertThat(resultsGrpcMock.blobId).isEqualTo(blobHandle.metadata().toCompletableFuture().join().id().toString());
+    assertThat(resultsGrpcMock.receivedData.toByteArray()).asString().isEqualTo("Hello");
   }
 
   @Test
@@ -117,10 +118,10 @@ class DefaultBlobServiceTest {
     blobService.uploadBlobData(blobHandle, BlobDefinition.from(payload)).toCompletableFuture().join();
 
     // Then
-    assertThat(resultsServiceMock.sessionId).isEqualTo(blobHandle.sessionHandle().id().toString());
-    assertThat(resultsServiceMock.blobId).isEqualTo(blobHandle.metadata().toCompletableFuture().join().id().toString());
-    assertThat(resultsServiceMock.dataChunkSizes).containsExactly(UPLOAD_CHUNK_SIZE, UPLOAD_CHUNK_SIZE, REMAINDER);
-    assertThat(resultsServiceMock.receivedData.toByteArray()).isEqualTo(payload);
+    assertThat(resultsGrpcMock.sessionId).isEqualTo(blobHandle.sessionHandle().id().toString());
+    assertThat(resultsGrpcMock.blobId).isEqualTo(blobHandle.metadata().toCompletableFuture().join().id().toString());
+    assertThat(resultsGrpcMock.dataChunkSizes).containsExactly(UPLOAD_CHUNK_SIZE, UPLOAD_CHUNK_SIZE, REMAINDER);
+    assertThat(resultsGrpcMock.receivedData.toByteArray()).isEqualTo(payload);
   }
 
 }

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/blob/event/DefaultBlobCompletionEventWatcherTest.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/blob/event/DefaultBlobCompletionEventWatcherTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.blob.event;
+
+import fr.aneo.armonik.client.blob.DefaultBlobService;
+import fr.aneo.armonik.client.mocks.EventsGrpcMock;
+import fr.aneo.armonik.client.mocks.ResultsGrpcMock;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.testing.GrpcCleanupRule;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.migrationsupport.rules.ExternalResourceSupport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static fr.aneo.armonik.api.grpc.v1.results.ResultStatusOuterClass.ResultStatus.RESULT_STATUS_ABORTED;
+import static fr.aneo.armonik.api.grpc.v1.results.ResultStatusOuterClass.ResultStatus.RESULT_STATUS_COMPLETED;
+import static fr.aneo.armonik.client.blob.BlobHandleFixture.blobHandle;
+import static fr.aneo.armonik.client.session.SessionHandleFixture.sessionHandle;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class DefaultBlobCompletionEventWatcherTest {
+
+  @RegisterExtension
+  public static final ExternalResourceSupport externalResourceSupport = new ExternalResourceSupport();
+
+  @Rule
+  public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private BlobCompletionEventWatcher blobCompletionEventWatcher;
+  private ResultsGrpcMock resultsGrpcMock;
+  private EventsGrpcMock eventsGrpcMock;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    resultsGrpcMock = new ResultsGrpcMock();
+    eventsGrpcMock = new EventsGrpcMock();
+    String serverName = InProcessServerBuilder.generateName();
+    grpcCleanup.register(InProcessServerBuilder.forName(serverName)
+                                               .directExecutor()
+                                               .addService(resultsGrpcMock)
+                                               .addService(eventsGrpcMock)
+                                               .build()
+                                               .start());
+
+    var channel = grpcCleanup.register(InProcessChannelBuilder.forName(serverName)
+                                                              .directExecutor()
+                                                              .build());
+    blobCompletionEventWatcher = new DefaultBlobCompletionEventWatcher(channel, new DefaultBlobService(channel));
+  }
+
+
+  @Test
+  void should_call_observer_on_success_when_blob_update_status_is_completed() {
+    // Given
+    var sessionHandle = sessionHandle();
+    var blobHandleId = randomUUID();
+    var observerMock = new BlobCompletionListenerMock();
+    resultsGrpcMock.setDownloadContentFor(blobHandleId, "Hello World !!".getBytes(UTF_8));
+
+    // when
+    var done = blobCompletionEventWatcher.watch(sessionHandle, List.of(blobHandle(blobHandleId)), observerMock);
+    eventsGrpcMock.emitStatusUpdate(blobHandleId, RESULT_STATUS_COMPLETED);
+    eventsGrpcMock.complete();
+    done.toCompletableFuture().join();
+
+    // then
+    assertThat(observerMock.blobErrors).isEmpty();
+    assertThat(observerMock.blobs).hasSize(1);
+    Assertions.assertThat(observerMock.blobs.get(0).data()).isEqualTo("Hello World !!".getBytes(UTF_8));
+    Assertions.assertThat(observerMock.blobs.get(0).metadata().id()).isEqualTo(blobHandleId);
+  }
+
+  @Test
+  void should_call_observer_on_error_when_blob_update_status_is_aborted() {
+    // Given
+    var sessionHandle = sessionHandle();
+    var blobHandleId = randomUUID();
+    var observerMock = new BlobCompletionListenerMock();
+
+
+    // when
+    var done = blobCompletionEventWatcher.watch(sessionHandle, List.of(blobHandle(blobHandleId)), observerMock);
+    eventsGrpcMock.emitStatusUpdate(blobHandleId, RESULT_STATUS_ABORTED);
+    eventsGrpcMock.complete();
+    done.toCompletableFuture().join();
+
+    // then
+    assertThat(observerMock.blobs).isEmpty();
+    assertThat(observerMock.blobErrors).hasSize(1);
+    Assertions.assertThat(observerMock.blobErrors.get(0).metadata().id()).isEqualTo(blobHandleId);
+  }
+
+  @Test
+  void should_call_observer_on_success_when_new_blob_status_is_completed() {
+    // Given
+    var sessionHandle = sessionHandle();
+    var blobHandleId = randomUUID();
+    var observerMock = new BlobCompletionListenerMock();
+    resultsGrpcMock.setDownloadContentFor(blobHandleId, "Hello World !!".getBytes(UTF_8));
+
+    // when
+    var done = blobCompletionEventWatcher.watch(sessionHandle, List.of(blobHandle(blobHandleId)), observerMock);
+    eventsGrpcMock.emitNewResult(blobHandleId, RESULT_STATUS_COMPLETED);
+    eventsGrpcMock.complete();
+    done.toCompletableFuture().join();
+
+    // then
+    assertThat(observerMock.blobErrors).isEmpty();
+    assertThat(observerMock.blobs).hasSize(1);
+    Assertions.assertThat(observerMock.blobs.get(0).data()).isEqualTo("Hello World !!".getBytes(UTF_8));
+    Assertions.assertThat(observerMock.blobs.get(0).metadata().id()).isEqualTo(blobHandleId);
+  }
+
+  @Test
+  void should_call_observer_on_error_when_new_blob_update_status_is_aborted() {
+    // Given
+    var sessionHandle = sessionHandle();
+    var blobHandleId = randomUUID();
+    var observerMock = new BlobCompletionListenerMock();
+
+    // when
+    var done = blobCompletionEventWatcher.watch(sessionHandle, List.of(blobHandle(blobHandleId)), observerMock);
+    eventsGrpcMock.emitNewResult(blobHandleId, RESULT_STATUS_ABORTED);
+    eventsGrpcMock.complete();
+    done.toCompletableFuture().join();
+
+    // then
+    assertThat(observerMock.blobs).isEmpty();
+    assertThat(observerMock.blobErrors).hasSize(1);
+    Assertions.assertThat(observerMock.blobErrors.get(0).metadata().id()).isEqualTo(blobHandleId);
+  }
+
+  @Test
+  void should_call_observer_on_error_when_downloading_blob_failed() {
+    // Given
+    var sessionHandle = sessionHandle();
+    var blobHandleId = randomUUID();
+    var completionListenerMock = new BlobCompletionListenerMock();
+    resultsGrpcMock.failDownloadFor(blobHandleId);
+
+    // when
+    var done = blobCompletionEventWatcher.watch(sessionHandle, List.of(blobHandle(blobHandleId)), completionListenerMock);
+    eventsGrpcMock.emitNewResult(blobHandleId, RESULT_STATUS_COMPLETED);
+    eventsGrpcMock.complete();
+    done.toCompletableFuture().join();
+
+    // then
+    assertThat(completionListenerMock.blobs).isEmpty();
+    assertThat(completionListenerMock.blobErrors).hasSize(1);
+    Assertions.assertThat(completionListenerMock.blobErrors.get(0).metadata().id()).isEqualTo(blobHandleId);
+  }
+
+  @Test
+  void should_complete_even_if_blob_listener_throws_on_success() {
+    // Given
+    var sessionHandle = sessionHandle();
+    var blobHandleId = randomUUID();
+    var failingListenerMock = new FailingListenerMock();
+    resultsGrpcMock.setDownloadContentFor(blobHandleId, "OK".getBytes(UTF_8));
+
+    // When
+    var done = blobCompletionEventWatcher.watch(sessionHandle, List.of(blobHandle(blobHandleId)), failingListenerMock);
+    eventsGrpcMock.emitNewResult(blobHandleId, RESULT_STATUS_COMPLETED);
+    eventsGrpcMock.complete();
+
+    // Then
+    assertThatCode(() -> done.toCompletableFuture().get(2, SECONDS)).doesNotThrowAnyException();
+    assertThat(done.toCompletableFuture()).isDone();
+    assertThat(done.toCompletableFuture()).isNotCompletedExceptionally();
+    assertThat(failingListenerMock.successCalls).isEqualTo(1);
+    assertThat(failingListenerMock.errorCalls).isEqualTo(0);
+  }
+
+  @Test
+  void should_complete_even_if_blob_listener_throws_on_error() {
+    // Given
+    var sessionHandle = sessionHandle();
+    var blobHandleId = randomUUID();
+    var failingListenerMock = new FailingListenerMock();
+
+    // When
+    var done = blobCompletionEventWatcher.watch(sessionHandle, List.of(blobHandle(blobHandleId)), failingListenerMock);
+    eventsGrpcMock.emitNewResult(blobHandleId, RESULT_STATUS_ABORTED);
+    eventsGrpcMock.complete();
+
+    // Then
+    assertThatCode(() -> done.toCompletableFuture().get(2, SECONDS)).doesNotThrowAnyException();
+    assertThat(done.toCompletableFuture()).isDone();
+    assertThat(done.toCompletableFuture()).isNotCompletedExceptionally();
+    assertThat(failingListenerMock.successCalls).isEqualTo(0);
+    assertThat(failingListenerMock.errorCalls).isEqualTo(1);
+  }
+
+  static class BlobCompletionListenerMock implements BlobCompletionListener {
+    List<Blob> blobs = new ArrayList<>();
+    List<BlobError> blobErrors = new ArrayList<>();
+
+    @Override
+    public void onSuccess(Blob blob) {
+      blobs.add(blob);
+    }
+
+    @Override
+    public void onError(BlobError blobError) {
+      blobErrors.add(blobError);
+    }
+  }
+
+  static class FailingListenerMock implements BlobCompletionListener {
+    int successCalls = 0;
+    int errorCalls = 0;
+    @Override
+    public void onSuccess(Blob blob) {
+      successCalls++;
+      throw new RuntimeException("boom in success");
+    }
+
+    @Override
+    public void onError(BlobError blobError) {
+      errorCalls++;
+      throw new RuntimeException("boom in failure");
+    }
+  }
+}

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/mocks/EventsGrpcMock.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/mocks/EventsGrpcMock.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.mocks;
+
+import fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventSubscriptionRequest;
+import fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventSubscriptionResponse;
+import fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventSubscriptionResponse.NewResult;
+import fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventSubscriptionResponse.ResultStatusUpdate;
+import fr.aneo.armonik.api.grpc.v1.events.EventsGrpc;
+import io.grpc.stub.StreamObserver;
+
+import java.util.UUID;
+
+import static fr.aneo.armonik.api.grpc.v1.results.ResultStatusOuterClass.*;
+
+public class EventsGrpcMock extends EventsGrpc.EventsImplBase {
+  private StreamObserver<EventSubscriptionResponse> streamObserver;
+
+  @Override
+  public void getEvents(EventSubscriptionRequest request, StreamObserver<EventSubscriptionResponse> responseObserver) {
+    this.streamObserver = responseObserver;
+  }
+
+  public void emitNewResult(UUID blobId, ResultStatus status) {
+    streamObserver.onNext(EventSubscriptionResponse.newBuilder()
+                                                   .setNewResult(NewResult.newBuilder()
+                                                                          .setResultId(blobId.toString())
+                                                                          .setStatus(status))
+                                                   .build());
+  }
+
+  public void emitStatusUpdate(UUID blobId, ResultStatus status) {
+    streamObserver.onNext(EventSubscriptionResponse.newBuilder()
+                                                   .setResultStatusUpdate(ResultStatusUpdate.newBuilder()
+                                                                                            .setResultId(blobId.toString())
+                                                                                            .setStatus(status))
+                                                   .build());
+  }
+
+  public void complete() {
+    if (streamObserver != null) {
+      streamObserver.onCompleted();
+    }
+  }
+}

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/mocks/TasksGrpcMock.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/mocks/TasksGrpcMock.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package fr.aneo.armonik.client.task;
+package fr.aneo.armonik.client.mocks;
 
 import fr.aneo.armonik.api.grpc.v1.tasks.TasksCommon.SubmitTasksResponse.TaskInfo;
 import fr.aneo.armonik.api.grpc.v1.tasks.TasksGrpc;
@@ -25,7 +25,7 @@ import java.util.stream.IntStream;
 import static fr.aneo.armonik.api.grpc.v1.tasks.TasksCommon.SubmitTasksRequest;
 import static fr.aneo.armonik.api.grpc.v1.tasks.TasksCommon.SubmitTasksResponse;
 
-public class TasksServiceMock extends TasksGrpc.TasksImplBase {
+public class TasksGrpcMock extends TasksGrpc.TasksImplBase {
 
   public SubmitTasksRequest submittedTasksRequest;
 

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/task/DefaultTaskServiceTest.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/task/DefaultTaskServiceTest.java
@@ -15,6 +15,7 @@
  */
 package fr.aneo.armonik.client.task;
 
+import fr.aneo.armonik.client.mocks.TasksGrpcMock;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.testing.GrpcCleanupRule;
@@ -42,15 +43,15 @@ class DefaultTaskServiceTest {
   public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
   private DefaultTaskService taskService;
-  private TasksServiceMock tasksServiceMock;
+  private TasksGrpcMock tasksGrpcMock;
 
   @BeforeEach
   void setUp() throws IOException {
-    tasksServiceMock = new TasksServiceMock();
+    tasksGrpcMock = new TasksGrpcMock();
     String serverName = InProcessServerBuilder.generateName();
     grpcCleanup.register(InProcessServerBuilder.forName(serverName)
                                                .directExecutor()
-                                               .addService(tasksServiceMock)
+                                               .addService(tasksGrpcMock)
                                                .build()
                                                .start());
 
@@ -87,22 +88,22 @@ class DefaultTaskServiceTest {
     assertThat(taskHandle.payLoad()).isEqualTo(payload);
 
     // payload
-    assertThat(tasksServiceMock.submittedTasksRequest.getSessionId()).isEqualTo(sessionHandle.id().toString());
+    assertThat(tasksGrpcMock.submittedTasksRequest.getSessionId()).isEqualTo(sessionHandle.id().toString());
 
     // Task options
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskOptions().getMaxRetries()).isEqualTo(3);
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskOptions().getPartitionId()).isEqualTo("partition_1");
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskOptions().getMaxDuration().getSeconds()).isEqualTo(3_600);
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskOptions().getMaxDuration().getNanos()).isEqualTo(0);
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskOptions().getPriority()).isEqualTo(1);
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskOptions().getOptionsMap()).isEqualTo(Map.of("option1", "value1"));
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskOptions().getMaxRetries()).isEqualTo(3);
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskOptions().getPartitionId()).isEqualTo("partition_1");
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskOptions().getMaxDuration().getSeconds()).isEqualTo(3_600);
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskOptions().getMaxDuration().getNanos()).isEqualTo(0);
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskOptions().getPriority()).isEqualTo(1);
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskOptions().getOptionsMap()).isEqualTo(Map.of("option1", "value1"));
 
     // Task Creation
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskCreationsCount()).isEqualTo(1);
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskCreations(0).getPayloadId()).isEqualTo("55555555-5555-5555-5555-555555555555");
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskCreations(0).getDataDependenciesList())
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskCreationsCount()).isEqualTo(1);
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskCreations(0).getPayloadId()).isEqualTo("55555555-5555-5555-5555-555555555555");
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskCreations(0).getDataDependenciesList())
       .containsExactlyInAnyOrder("11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222");
-    assertThat(tasksServiceMock.submittedTasksRequest.getTaskCreations(0).getExpectedOutputKeysList())
+    assertThat(tasksGrpcMock.submittedTasksRequest.getTaskCreations(0).getExpectedOutputKeysList())
       .containsExactlyInAnyOrder("33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444");
   }
 }


### PR DESCRIPTION
# Motivation
Introduce a first version of the task output callback process to enable reactive handling of outputs. This is an initial iteration that will be reworked and refined, but already provides a basic end-to-end flow managed by ArmoniKClient, from TaskDefinition to output completion callbacks.


# Description
- First version of an optional task output callback mechanism:
    - Users can register a BlobCompletionListener to receive callbacks when task outputs complete (success or failure).
    - An internal batching/watching component tracks outputs declared during task submission and dispatches callbacks accordingly.

- ArmoniKClient integration:
    - When a listener is configured, submitTask automatically enqueues declared outputs for event-based completion tracking.
    - Added waitUntilFinished() to block until the currently pending outputs (at call time) have reached a terminal state and have been processed by the listener.

- Services facade exposes an event watcher for result/blob completion events and wires a default implementation.
- Builder now supports withTaskOutputListener(...) to keep the feature opt-in.
- Performance: Event stream is created only when a listener is configured; blob downloads are asynchronous to avoid blocking.