### PR TITLE
 feat: implement batching and parallelism for output listener

### DIFF
--- a/armonik-client/pom.xml
+++ b/armonik-client/pom.xml
@@ -97,6 +97,12 @@
       <version>${logback.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock</artifactId>
+      <version>2.13.1</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
   <build>

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/internal/concurrent/Schedulers.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/internal/concurrent/Schedulers.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.internal.concurrent;
+
+import fr.aneo.armonik.client.model.BatchingPolicy;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * Utility class providing shared scheduled executor services for the ArmoniK client.
+ * <p>
+ * This class manages a singleton {@link ScheduledThreadPoolExecutor} instance that is used
+ * throughout the ArmoniK client for scheduling delayed operations, timers, and periodic tasks.
+ * The shared executor is optimized for the client's batching and coordination needs.
+ * <p>
+ * The shared scheduler is configured with:
+ * <ul>
+ *   <li><strong>Single thread:</strong> Uses one daemon thread to minimize resource overhead</li>
+ *   <li><strong>Daemon thread:</strong> Won't prevent JVM shutdown</li>
+ *   <li><strong>Optimized cleanup:</strong> Removes canceled tasks immediately to prevent memory leaks</li>
+ *   <li><strong>Shutdown behavior:</strong> Doesn't execute delayed tasks after shutdown</li>
+ * </ul>
+ * <p>
+ * A JVM shutdown hook is automatically registered to properly shut down the executor when
+ * the application terminates, ensuring clean resource cleanup.
+ *
+ * @see BatchingPolicy
+ */
+public class Schedulers {
+
+  /**
+   * The shared scheduled thread pool executor instance.
+   * <p>
+   * This executor is configured as a single-threaded daemon scheduler with optimized
+   * cleanup policies for the ArmoniK client's scheduling needs.
+   */
+  private static final ScheduledThreadPoolExecutor SHARED;
+
+  private Schedulers() {}
+
+  static {
+    SHARED = new ScheduledThreadPoolExecutor(
+      1,
+      r -> {
+        Thread t = new Thread(r, "armonik-scheduler");
+        t.setDaemon(true);
+        return t;
+      }
+    );
+    SHARED.setRemoveOnCancelPolicy(true);
+    SHARED.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+
+    Runtime.getRuntime().addShutdownHook(new Thread(SHARED::shutdown, "armonik-scheduler-shutdown"));
+  }
+
+  /**
+   * Returns the shared scheduled executor service for the ArmoniK client.
+   * <p>
+   * This method provides access to the singleton {@link ScheduledExecutorService} instance
+   * that is used throughout the client for scheduling operations. The executor is:
+   * <ul>
+   *   <li><strong>Thread-safe:</strong> Can be safely accessed from multiple threads</li>
+   *   <li><strong>Singleton:</strong> The same instance is returned on every call</li>
+   *   <li><strong>Lifecycle-managed:</strong> Automatically shutdown during JVM termination</li>
+   * </ul>
+   * <p>
+   * <strong>Usage Guidelines:</strong>
+   * <ul>
+   *   <li>Do not call {@code shutdown()} on the returned executor</li>
+   *   <li>Prefer this over creating new schedulers for better resource utilization</li>
+   *   <li>Use {@code schedule()} methods for delayed operations</li>
+   *   <li>Use {@code scheduleWithFixedDelay()} for periodic operations with cleanup needs</li>
+   * </ul>
+   *
+   * @return the shared scheduled executor service
+   */
+  public static ScheduledExecutorService shared() {
+    return SHARED;
+  }
+}

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/internal/grpc/mappers/BlobMapper.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/internal/grpc/mappers/BlobMapper.java
@@ -16,6 +16,7 @@
 package fr.aneo.armonik.client.internal.grpc.mappers;
 
 import com.google.protobuf.UnsafeByteOperations;
+import fr.aneo.armonik.api.grpc.v1.results.ResultsCommon.CreateResultsMetaDataRequest.ResultCreate;
 import fr.aneo.armonik.client.model.BlobId;
 import fr.aneo.armonik.client.model.SessionId;
 
@@ -32,28 +33,28 @@ public final class BlobMapper {
     return CreateResultsMetaDataRequest.newBuilder()
                                        .setSessionId(sessionId.asString())
                                        .addAllResults(IntStream.range(0, count)
-                                                               .mapToObj(index -> CreateResultsMetaDataRequest.ResultCreate.newBuilder().build())
+                                                               .mapToObj(index -> ResultCreate.newBuilder().build())
                                                                .toList())
                                        .build();
   }
 
   public static DownloadResultDataRequest toDownloadResultDataRequest(SessionId sessionId, BlobId blobId) {
-   return DownloadResultDataRequest.newBuilder()
-                                          .setSessionId(sessionId.asString()).setResultId(blobId.asString())
-                                          .build();
+    return DownloadResultDataRequest.newBuilder()
+                                    .setSessionId(sessionId.asString()).setResultId(blobId.asString())
+                                    .build();
   }
 
   public static UploadResultDataRequest toUploadResultDataRequest(byte[] data, int offset, int size) {
     return UploadResultDataRequest.newBuilder()
-                           .setDataChunk(UnsafeByteOperations.unsafeWrap(data, offset, size))
-                           .build();
+                                  .setDataChunk(UnsafeByteOperations.unsafeWrap(data, offset, size))
+                                  .build();
   }
 
   public static UploadResultDataRequest toUploadResultDataIdentifierRequest(SessionId sessionId, BlobId blobId) {
     return UploadResultDataRequest.newBuilder()
-                           .setId(UploadResultDataRequest.ResultIdentifier.newBuilder()
-                                                                          .setResultId(blobId.asString())
-                                                                          .setSessionId(sessionId.asString()))
-                           .build();
+                                  .setId(UploadResultDataRequest.ResultIdentifier.newBuilder()
+                                                                                 .setResultId(blobId.asString())
+                                                                                 .setSessionId(sessionId.asString()))
+                                  .build();
   }
 }

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/internal/grpc/mappers/EventMapper.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/internal/grpc/mappers/EventMapper.java
@@ -15,16 +15,17 @@
  */
 package fr.aneo.armonik.client.internal.grpc.mappers;
 
-import fr.aneo.armonik.api.grpc.v1.FiltersCommon;
-import fr.aneo.armonik.api.grpc.v1.events.EventsCommon;
-import fr.aneo.armonik.api.grpc.v1.results.ResultsFields;
+import fr.aneo.armonik.api.grpc.v1.results.ResultsFields.ResultField;
+import fr.aneo.armonik.api.grpc.v1.results.ResultsFields.ResultRawField;
 import fr.aneo.armonik.api.grpc.v1.results.ResultsFilters;
 import fr.aneo.armonik.client.model.BlobId;
 import fr.aneo.armonik.client.model.SessionId;
 
 import java.util.Set;
 
+import static fr.aneo.armonik.api.grpc.v1.FiltersCommon.FilterString;
 import static fr.aneo.armonik.api.grpc.v1.FiltersCommon.FilterStringOperator.FILTER_STRING_OPERATOR_EQUAL;
+import static fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventSubscriptionRequest;
 import static fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventsEnum.EVENTS_ENUM_NEW_RESULT;
 import static fr.aneo.armonik.api.grpc.v1.events.EventsCommon.EventsEnum.EVENTS_ENUM_RESULT_STATUS_UPDATE;
 import static fr.aneo.armonik.api.grpc.v1.results.ResultsFields.ResultRawEnumField.RESULT_RAW_ENUM_FIELD_RESULT_ID;
@@ -34,24 +35,24 @@ public final class EventMapper {
   private EventMapper() {
   }
 
-  public static EventsCommon.EventSubscriptionRequest createEventSubscriptionRequest(SessionId sessionId, Set<BlobId> blobIds) {
-    var resultRawField = ResultsFields.ResultField.newBuilder().setResultRawField(ResultsFields.ResultRawField.newBuilder().setField(RESULT_RAW_ENUM_FIELD_RESULT_ID));
-    var filterOperator = FiltersCommon.FilterString.newBuilder().setOperator(FILTER_STRING_OPERATOR_EQUAL);
+  public static EventSubscriptionRequest createEventSubscriptionRequest(SessionId sessionId, Set<BlobId> blobIds) {
+    var resultRawField = ResultField.newBuilder().setResultRawField(ResultRawField.newBuilder().setField(RESULT_RAW_ENUM_FIELD_RESULT_ID));
+    var filterOperator = FilterString.newBuilder().setOperator(FILTER_STRING_OPERATOR_EQUAL);
     var filterFieldBuilder = ResultsFilters.FilterField.newBuilder()
                                                        .setField(resultRawField)
                                                        .setFilterString(filterOperator);
 
     var resultFiltersBuilder = ResultsFilters.Filters.newBuilder();
     blobIds.forEach(blobId -> {
-      filterFieldBuilder.setFilterString(FiltersCommon.FilterString.newBuilder().setValue(blobId.asString()));
+      filterFieldBuilder.setFilterString(FilterString.newBuilder().setValue(blobId.asString()));
       resultFiltersBuilder.addOr(ResultsFilters.FiltersAnd.newBuilder().addAnd(filterFieldBuilder));
     });
 
-    return EventsCommon.EventSubscriptionRequest.newBuilder()
-                                                .setResultsFilters(resultFiltersBuilder)
-                                                .addReturnedEvents(EVENTS_ENUM_RESULT_STATUS_UPDATE)
-                                                .addReturnedEvents(EVENTS_ENUM_NEW_RESULT)
-                                                .setSessionId(sessionId.asString())
-                                                .build();
+    return EventSubscriptionRequest.newBuilder()
+                                   .setResultsFilters(resultFiltersBuilder)
+                                   .addReturnedEvents(EVENTS_ENUM_RESULT_STATUS_UPDATE)
+                                   .addReturnedEvents(EVENTS_ENUM_NEW_RESULT)
+                                   .setSessionId(sessionId.asString())
+                                   .build();
   }
 }

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/internal/grpc/mappers/TaskMapper.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/internal/grpc/mappers/TaskMapper.java
@@ -28,11 +28,11 @@ import static fr.aneo.armonik.api.grpc.v1.tasks.TasksCommon.SubmitTasksRequest;
 
 public final class TaskMapper {
 
-  public static TaskCreation toTaskCreation(List<BlobId> inputBlobIds,List<BlobId> outputBlobIds, BlobId payloadId, TaskConfiguration taskConfiguration) {
+  public static TaskCreation toTaskCreation(List<BlobId> inputBlobIds, List<BlobId> outputBlobIds, BlobId payloadId, TaskConfiguration taskConfiguration) {
     var builder = TaskCreation.newBuilder()
-                                                             .setPayloadId(payloadId.asString())
-                                                             .addAllDataDependencies(inputBlobIds.stream().map(BlobId::asString).toList())
-                                                             .addAllExpectedOutputKeys(outputBlobIds.stream().map(BlobId::asString).toList());
+                              .setPayloadId(payloadId.asString())
+                              .addAllDataDependencies(inputBlobIds.stream().map(BlobId::asString).toList())
+                              .addAllExpectedOutputKeys(outputBlobIds.stream().map(BlobId::asString).toList());
     if (taskConfiguration != null) {
       builder.setTaskOptions(toTaskOptions(taskConfiguration));
     }
@@ -42,10 +42,10 @@ public final class TaskMapper {
 
   public static SubmitTasksRequest toSubmitTasksRequest(SessionId sessionId, TaskConfiguration taskConfig, TaskCreation taskCreation) {
     return SubmitTasksRequest.newBuilder()
-                                         .setSessionId(sessionId.asString())
-                                         .setTaskOptions(toTaskOptions(taskConfig))
-                                         .addTaskCreations(taskCreation)
-                                         .build();
+                             .setSessionId(sessionId.asString())
+                             .setTaskOptions(toTaskOptions(taskConfig))
+                             .addTaskCreations(taskCreation)
+                             .build();
   }
 
   public static TaskOptions toTaskOptions(TaskConfiguration taskConfiguration) {

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/model/BatchingPolicy.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/model/BatchingPolicy.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.model;
+
+import fr.aneo.armonik.client.definition.SessionDefinition;
+
+import java.time.Duration;
+
+/**
+ * Immutable policy that defines when buffered items should be flushed and how they are grouped into batches.
+ * <p>
+ * This policy is used by {@link BlobCompletionCoordinator} to optimize blob completion monitoring operations
+ * through efficient batching strategies. It provides fine-grained control over the trade-offs between
+ * latency, throughput, and resource utilization.
+ *
+ * <h2>Policy Parameters</h2>
+ * <ul>
+ *   <li><strong>Size trigger</strong> — {@link #batchSize()}: when the number of buffered items
+ *       reaches this threshold, a flush is triggered. This is a <em>threshold</em>, not a cap.</li>
+ *
+ *   <li><strong>Time trigger</strong> — {@link #maxDelay()}: even if the size trigger is not
+ *       reached, a flush occurs once the oldest item has waited this long.</li>
+ *
+ *   <li><strong>Parallelism</strong> — {@link #maxConcurrentBatches()}: at most this many batch
+ *       flush operations may be in flight at the same time.</li>
+ *
+ *   <li><strong>Per-batch cap</strong> — {@link #capPerBatch()}: an upper bound on how many items
+ *       are included in a <em>single</em> batch flush. If more items are available, they are split
+ *       into multiple batches, each no larger than this value.</li>
+ * </ul>
+ *
+ * <h2>Batching Semantics</h2>
+ * <ul>
+ *   <li>A flush is initiated when <em>either</em> the size trigger is reached
+ *       (<code>bufferedItems &gt;= batchSize</code>) <em>or</em> the time trigger expires
+ *       (<code>oldestItemAge &gt;= maxDelay</code>).</li>
+ *   <li>On flush, buffered items may be divided into multiple chunks according to
+ *       {@link #capPerBatch()}. Each chunk is processed as a separate batch, subject to
+ *       {@link #maxConcurrentBatches()}.</li>
+ *   <li>Use {@link #batchSize()} and {@link #maxDelay()} to trade <em>latency</em> for
+ *       <em>throughput</em>: smaller values flush sooner; larger values amortize overhead better.</li>
+ *   <li>Use {@link #capPerBatch()} to keep individual batches within safe/efficient limits
+ *       (e.g., gRPC message size limits or memory constraints).</li>
+ *   <li>Use {@link #maxConcurrentBatches()} to control overall concurrency independently of size
+ *       and time triggers.</li>
+ * </ul>
+ *
+ * <h2>Usage Context</h2>
+ * <p>
+ * BatchingPolicy is primarily used within {@link SessionDefinition} to configure how task output
+ * completion events are batched for efficient processing. The policy affects the responsiveness
+ * and resource usage of blob completion monitoring operations.
+ *
+ * <p><strong>Thread-safety:</strong> This class is immutable and therefore thread-safe.
+ *
+ * @param batchSize             size-based flush trigger (threshold; must be &gt; 0)
+ * @param maxDelay              time-based flush trigger (max buffering delay; must be &gt; 0)
+ * @param maxConcurrentBatches  maximum number of batches processed concurrently (must be &gt; 0)
+ * @param capPerBatch           hard cap on the number of items included in a single batch (must be &gt; 0)
+ * @see BlobCompletionCoordinator
+ * @see SessionDefinition
+ */
+public record BatchingPolicy(
+  int batchSize,
+  Duration maxDelay,
+  int maxConcurrentBatches,
+  int capPerBatch
+) {
+  /**
+   * A conservative default policy that balances responsiveness with throughput efficiency.
+   * <p>
+   * The default values are optimized for typical blob completion monitoring scenarios:
+   * <ul>
+   *   <li><strong>batchSize = 50</strong> — triggers flush after 50 items, providing good throughput</li>
+   *   <li><strong>maxDelay = 200ms</strong> — ensures responsive processing even with low item rates</li>
+   *   <li><strong>maxConcurrentBatches = 5</strong> — allows moderate parallelism without overwhelming the system</li>
+   *   <li><strong>capPerBatch = 100</strong> — keeps individual batch sizes manageable for gRPC operations</li>
+   * </ul>
+   * These defaults work well for most applications but can be customized based on specific
+   * performance requirements and cluster characteristics.
+   *
+   * @see SessionDefinition
+   */
+  public static final BatchingPolicy DEFAULT = new BatchingPolicy(50, Duration.ofMillis(200), 5, 100);
+
+  /**
+   * Validates all policy parameters and their relationships.
+   * <p>
+   * This compact constructor ensures that:
+   * <ul>
+   *   <li>All numeric values are positive</li>
+   *   <li>The delay duration is positive and non-null</li>
+   *   <li>Parameter values are within reasonable bounds</li>
+   * </ul>
+   *
+   * @throws IllegalArgumentException if {@code batchSize}, {@code maxConcurrentBatches},
+   *                                  or {@code capPerBatch} is {@code <= 0}
+   * @throws IllegalArgumentException if {@code maxDelay} is {@code null}, zero, or negative
+   */
+  public BatchingPolicy {
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("batchSize must be > 0, got: " + batchSize);
+    }
+    if (maxConcurrentBatches <= 0) {
+      throw new IllegalArgumentException("maxConcurrentBatches must be > 0, got: " + maxConcurrentBatches);
+    }
+    if (capPerBatch <= 0) {
+      throw new IllegalArgumentException("capPerBatch must be > 0, got: " + capPerBatch);
+    }
+    if (maxDelay == null || maxDelay.isZero() || maxDelay.isNegative()) {
+      throw new IllegalArgumentException("maxDelay must be > 0, got: " + maxDelay);
+    }
+  }
+}

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/model/BlobCompletionCoordinator.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/model/BlobCompletionCoordinator.java
@@ -15,77 +15,349 @@
  */
 package fr.aneo.armonik.client.model;
 
+import fr.aneo.armonik.client.definition.SessionDefinition;
+import fr.aneo.armonik.client.internal.concurrent.Schedulers;
 import io.grpc.ManagedChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.*;
 
-import static fr.aneo.armonik.client.internal.concurrent.Futures.allOf;
+import static java.lang.Math.min;
+import static java.util.List.copyOf;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
- * Basic batching utility for managing multiple blob completion watching operations.
+ * Coordinator for managing batched blob completion monitoring operations within a session.
  * <p>
- * This class provides a simple mechanism to coordinate multiple concurrent blob watching
- * operations through a single {@link BlobCompletionEventWatcher} instance. It allows
- * enqueueing multiple watch requests and waiting for their collective completion.
- *
+ * This class provides efficient batching and coordination of blob completion watching operations
+ * for a session context. It manages multiple concurrent blob monitoring requests through a single
+ * {@link BlobCompletionEventWatcher} instance, optimizing resource usage and network efficiency.
  * <p>
- * <strong>Note:</strong> This is a basic implementation that will be fully reworked in
- * future versions. The current design is intended for simple use cases and may not be
- * suitable for high-throughput or complex batching scenarios.
+ * The coordinator operates on a batching model where:
+ * <ul>
+ *   <li>Blob handles are enqueued for monitoring</li>
+ *   <li>Enqueued handles are batched according to configured policies</li>
+ *   <li>Batches are submitted to the event watcher for cluster monitoring</li>
+ *   <li>Completion events are delivered through the session's configured {@link BlobCompletionListener}</li>
+ * </ul>
+ * <p>
+ * This class is used internally by {@link SessionHandle} to coordinate task output completion
+ * monitoring and should not be used directly by client applications.
  *
  * @see BlobCompletionEventWatcher
  * @see BlobCompletionListener
+ * @see SessionHandle#awaitOutputsProcessed()
  */
+final class BlobCompletionCoordinator {
 
-public class BlobCompletionCoordinator {
+  private static final Logger logger = LoggerFactory.getLogger(BlobCompletionCoordinator.class);
 
+  private final Semaphore permits;
   private final BlobCompletionEventWatcher watcher;
-  private final BlobCompletionListener listener;
-
   private final Queue<CompletionStage<Void>> inFlightStages = new ConcurrentLinkedQueue<>();
+  private final BatchingPolicy batchingPolicy;
+  private final ScheduledExecutorService scheduler;
+  private final Object lock = new Object();
+  private final List<BlobHandle> buffer = new ArrayList<>();
+  private ScheduledFuture<?> timer;
+  private CompletableFuture<Void> idleFuture;
 
   /**
-   * Creates a new batcher that will use the specified watcher and listener for all operations.
-   *
-   * @param listener the listener to receive completion events; must not be {@code null}
-   * @throws NullPointerException if either parameter is {@code null}
-   */
-  public BlobCompletionCoordinator(ManagedChannel channel, BlobCompletionListener listener) {
-    this.watcher = new BlobCompletionEventWatcher(channel);
-    this.listener = listener;
-  }
-
-  /**
-   * Enqueues a new blob watching operation to be tracked by this batcher.
-   *
-   * @param sessionId the session context for the blobs to watch; must not be {@code null}
-   * @param blobHandles   the blob handles to monitor; must not be {@code null}
-   * @throws NullPointerException if any parameter is {@code null}
-   */
-  public void enqueue(SessionId sessionId, List<BlobHandle> blobHandles) {
-    inFlightStages.add(watcher.watch(sessionId, blobHandles, listener));
-  }
-
-  /**
-   * Returns a completion stage that completes when all currently enqueued operations finish.
+   * Creates a new blob completion coordinator for the specified session.
    * <p>
-   * This method takes a snapshot of all in-flight operations at the time of invocation
-   * and returns a stage that completes when all of them reach terminal states.
-   * Operations enqueued after calling this method are not included in the returned stage.
-   * </p>
+   * This constructor initializes the coordinator with default batching policies
+   * and a dedicated event watcher for efficient blob completion monitoring.
+   * The coordinator will use the session's configured blob completion listener
+   * for all completion event notifications.
+   *
+   * @param sessionId the identifier of the session this coordinator serves
+   * @param channel   the gRPC channel for cluster communication
+   * @throws NullPointerException if any parameter is null
+   * @see SessionId
+   * @see BlobCompletionListener
+   * @see BlobCompletionEventWatcher
+   */
+  BlobCompletionCoordinator(SessionId sessionId, ManagedChannel channel, SessionDefinition sessionDefinition) {
+    this(
+      new BlobCompletionEventWatcher(sessionId, channel, sessionDefinition.outputListener()),
+      sessionDefinition.outputBatchingPolicy(),
+      Schedulers.shared()
+    );
+  }
+
+  /**
+   * Creates a blob completion coordinator with custom batching configuration.
+   * <p>
+   * This constructor allows specification of custom batching policies and schedulers
+   * for advanced coordination scenarios. It is primarily used for testing or when
+   * specific batching behavior is required.
+   *
+   * @param watcher        the event watcher to use for blob completion monitoring
+   * @param batchingPolicy the policy defining how blob handles are batched
+   * @param scheduler      the executor service for batching timer operations
+   * @throws NullPointerException if any parameter is null
+   * @see BatchingPolicy
+   * @see ScheduledExecutorService
+   */
+  BlobCompletionCoordinator(BlobCompletionEventWatcher watcher,
+                            BatchingPolicy batchingPolicy,
+                            ScheduledExecutorService scheduler
+  ) {
+    requireNonNull(watcher, "watcher must not be null");
+    requireNonNull(batchingPolicy, "batchingPolicy must not be null");
+    requireNonNull(scheduler, "scheduler must not be null");
+
+    this.watcher = watcher;
+    this.batchingPolicy = batchingPolicy;
+    this.scheduler = scheduler;
+    this.permits = new Semaphore(batchingPolicy.maxConcurrentBatches());
+  }
+
+
+  /**
+   * Enqueues blob handles for completion monitoring.
+   * <p>
+   * This method adds the specified blob handles to the monitoring queue. The handles
+   * will be batched according to the configured batching policy and submitted for
+   * cluster monitoring. The session's blob completion listener will be notified
+   * when these blobs reach terminal states.
+   * <p>
+   * The operation is asynchronous and non-blocking. Enqueued blob handles are
+   * processed in the background according to the batching schedule.
+   *
+   * @param blobHandles the list of blob handles to monitor for completion
+   * @throws NullPointerException if blobHandles is null
+   * @see BlobHandle
+   * @see BlobCompletionListener
+   */
+  public void enqueue(List<BlobHandle> blobHandles) {
+    if (blobHandles != null && !blobHandles.isEmpty()) {
+      logger.atTrace()
+            .addKeyValue("operation", "enqueue")
+            .addKeyValue("added", blobHandles.size())
+            .log("Enqueue blob handles");
+
+      boolean shouldArmTimer = false;
+      boolean hitSizeTrigger;
+
+      synchronized (lock) {
+        if (buffer.isEmpty()) {
+          shouldArmTimer = true;
+        }
+        buffer.addAll(blobHandles);
+        hitSizeTrigger = buffer.size() >= batchingPolicy.batchSize();
+
+        final int sizeNow = buffer.size();
+        if (shouldArmTimer && timer == null) {
+          timer = scheduler.schedule(this::onTimer, batchingPolicy.maxDelay().toNanos(), NANOSECONDS);
+          logger.atDebug()
+                .addKeyValue("operation", "enqueue")
+                .addKeyValue("bufferSize", sizeNow)
+                .addKeyValue("maxDelayNanos", batchingPolicy.maxDelay().toNanos())
+                .log("Timer armed for batch");
+        } else {
+          logger.atTrace()
+                .addKeyValue("operation", "enqueue")
+                .addKeyValue("bufferSize", sizeNow)
+                .log("Timer already armed or not needed");
+        }
+      }
+      if (hitSizeTrigger) {
+        logger.atDebug()
+              .addKeyValue("operation", "enqueue")
+              .addKeyValue("bufferSize", "triggered")
+              .log("Batch size threshold reached; flushing now");
+
+        flush();
+      }
+    }
+  }
+
+  /**
+   * Returns a completion stage that completes when all currently tracked operations finish.
+   * <p>
+   * This method provides a synchronization point for waiting until all blob completion
+   * operations that were enqueued at the time of invocation have reached terminal states.
+   * The returned completion stage takes a snapshot of in-flight operations and excludes
+   * any operations enqueued after this method is called.
+   * <p>
+   * If no operations are currently in progress, the returned completion stage is
+   * already completed. This method does not cancel any ongoing operations.
    *
    * @return a completion stage that completes when all current operations finish,
-   *         or a completed stage if no operations are in progress
+   * or an already completed stage if no operations are in progress
    */
-  public CompletionStage<Void> waitUntilFinished() {
-    var snapshot = new ArrayList<>(inFlightStages);
-    if (snapshot.isEmpty()) return completedFuture(null);
+  public CompletionStage<Void> waitUntilIdle() {
+    logger.atDebug()
+          .addKeyValue("operation", "waitUntilIdle")
+          .addKeyValue("inFlight", inFlightStages.size())
+          .addKeyValue("buffer", buffer.size())
+          .log("Waiting until coordinator becomes idle");
 
-    return allOf(snapshot).thenApply(v -> null);
+    flush();
+    synchronized (lock) {
+      if (buffer.isEmpty() && inFlightStages.isEmpty()) {
+        return completedFuture(null);
+      }
+      if (idleFuture == null || idleFuture.isDone()) {
+        idleFuture = new CompletableFuture<>();
+      }
+
+      return idleFuture.handle((ok, ex) -> null);
+    }
+  }
+
+  private void onTimer() {
+    logger.atDebug()
+          .addKeyValue("operation", "onTimer")
+          .log("Batch timer fired");
+
+    flush();
+    maybeSignalIdle();
+  }
+
+  private void flush() {
+    logger.atTrace()
+          .addKeyValue("operation", "flush")
+          .log("Flushing buffer");
+
+    var drained = drainBatchLocked();
+    if (!drained.isEmpty()) {
+      logger.atDebug()
+            .addKeyValue("operation", "flush")
+            .addKeyValue("drained", drained.size())
+            .log("Drained items from buffer");
+
+      var remaining = new ArrayList<List<BlobHandle>>();
+      var batches = fixedSizeBatches(drained, batchingPolicy.capPerBatch());
+
+      batches.forEach(batch -> {
+          if (permits.tryAcquire()) {
+            logger.atDebug()
+                  .addKeyValue("operation", "dispatch")
+                  .addKeyValue("size", batch.size())
+                  .addKeyValue("permitsRemaining", permits.availablePermits() - 1)
+                  .log("Dispatching batch to watcher");
+
+            startWatch(batch);
+          } else {
+            logger.atTrace()
+                  .addKeyValue("operation", "flush")
+                  .addKeyValue("size", batch.size())
+                  .log("No permit available; re-buffering batch");
+
+            remaining.add(batch);
+          }
+        }
+      );
+
+      if (!remaining.isEmpty()) {
+        logger.atDebug()
+              .addKeyValue("operation", "flush")
+              .addKeyValue("rebufferedBatches", remaining.size())
+              .log("Re-buffered due to saturation");
+
+        pushBackFront(remaining);
+      }
+    }
+    maybeSignalIdle();
+  }
+
+  private List<BlobHandle> drainBatchLocked() {
+    synchronized (lock) {
+      List<BlobHandle> drained = List.of();
+      if (!buffer.isEmpty()) {
+        drained = copyOf(buffer);
+        buffer.clear();
+        if (timer != null) {
+          timer.cancel(false);
+          timer = null;
+        }
+      }
+      return drained;
+    }
+  }
+
+  private void startWatch(List<BlobHandle> batch) {
+    logger.atTrace()
+          .addKeyValue("operation", "startWatch")
+          .addKeyValue("size", batch.size())
+          .log("Starting watch for batch");
+
+    var stage = watcher.watch(batch);
+    inFlightStages.add(stage);
+    stage.whenComplete((ok, ex) -> {
+      final boolean failed = (ex != null);
+      logger.atDebug()
+            .addKeyValue("operation", "completion")
+            .addKeyValue("size", batch.size())
+            .addKeyValue("status", failed ? "failed" : "ok")
+            .log("Watcher completion");
+      permits.release();
+      inFlightStages.remove(stage);
+      flush();
+      maybeSignalIdle();
+    });
+  }
+
+  private void pushBackFront(List<List<BlobHandle>> chunks) {
+    synchronized (lock) {
+      var safeChunks = requireNonNullElse(chunks, List.<List<BlobHandle>>of());
+      var head = safeChunks.stream()
+                           .filter(c -> c != null && !c.isEmpty())
+                           .flatMap(List::stream)
+                           .collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
+
+      if (!head.isEmpty()) {
+        logger.atTrace()
+              .addKeyValue("operation", "pushBackFront")
+              .addKeyValue("prepended", head.size())
+              .addKeyValue("prevBuffer", buffer.size())
+              .log("Prepending items to buffer");
+        head.addAll(buffer);
+        buffer.clear();
+        buffer.addAll(head);
+      }
+
+      if (timer == null && !buffer.isEmpty()) {
+        timer = scheduler.schedule(this::onTimer, batchingPolicy.maxDelay().toNanos(), NANOSECONDS);
+      }
+    }
+  }
+
+  private void maybeSignalIdle() {
+    CompletableFuture<Void> toComplete = null;
+    synchronized (lock) {
+      if (idleFuture != null && !idleFuture.isDone()
+        && buffer.isEmpty()
+        && inFlightStages.isEmpty()) {
+        toComplete = idleFuture;
+      }
+    }
+    if (toComplete != null) {
+      logger.atDebug()
+            .addKeyValue("operation", "idle")
+            .log("Coordinator is idle; signaling waiters");
+      toComplete.complete(null);
+    }
+  }
+
+
+  private static List<List<BlobHandle>> fixedSizeBatches(List<BlobHandle> blobHandles, int batchSize) {
+    if (batchSize <= 0) throw new IllegalArgumentException("batchSize must be positive");
+
+    var partitions = new ArrayList<List<BlobHandle>>();
+    for (int i = 0; i < blobHandles.size(); i += batchSize) {
+      partitions.add(copyOf(blobHandles.subList(i, min(i + batchSize, blobHandles.size()))));
+    }
+
+    return partitions;
   }
 }

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/model/SessionHandle.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/model/SessionHandle.java
@@ -65,7 +65,7 @@ public final class SessionHandle {
     requireNonNull(channel, "channel must not be null");
 
     this.sessionInfo = sessionInfo;
-    this.taskSubmitter = new TaskSubmitter(sessionInfo.id(), sessionDefinition.taskConfiguration(), sessionDefinition.taskOutputsListener(), channel);
+    this.taskSubmitter = new TaskSubmitter(sessionInfo.id(), sessionDefinition, channel);
   }
 
   /**

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/model/TaskSubmitter.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/model/TaskSubmitter.java
@@ -19,6 +19,7 @@ import com.google.gson.Gson;
 import fr.aneo.armonik.api.grpc.v1.tasks.TasksCommon.SubmitTasksRequest.TaskCreation;
 import fr.aneo.armonik.api.grpc.v1.tasks.TasksGrpc;
 import fr.aneo.armonik.client.definition.BlobDefinition;
+import fr.aneo.armonik.client.definition.SessionDefinition;
 import fr.aneo.armonik.client.definition.TaskDefinition;
 import fr.aneo.armonik.client.internal.concurrent.Futures;
 import fr.aneo.armonik.client.internal.grpc.mappers.TaskMapper;
@@ -46,16 +47,28 @@ import static fr.aneo.armonik.client.model.TaskConfiguration.defaultConfiguratio
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
+
 /**
- * Internal component responsible for submitting tasks to the ArmoniK cluster.
+ * Internal component responsible for orchestrating task submission to the ArmoniK cluster.
  * <p>
- * This class handles the complex process of task submission including blob allocation,
- * data upload, task creation, and output completion coordination. It serves as the
- * implementation backend for {@link SessionHandle#submitTask(TaskDefinition)} and
- * manages all gRPC interactions required for task submission.
+ * This class handles the complete task submission pipeline, including blob allocation, data upload,
+ * task creation, and output completion coordination. It serves as the implementation backend for
+ * {@link SessionHandle#submitTask(TaskDefinition)} and manages all gRPC interactions required
+ * for task submission.
+ * <p>
+ * The task submission process follows these steps:
+ * <ol>
+ *   <li><strong>Blob Allocation:</strong> Allocates blob handles for inputs, outputs, and payload</li>
+ *   <li><strong>Input Upload:</strong> Uploads input data from {@link BlobDefinition}s to the cluster</li>
+ *   <li><strong>Payload Creation:</strong> Serializes task metadata (input/output mappings) as JSON payload</li>
+ *   <li><strong>Task Submission:</strong> Submits the task with dependencies to the ArmoniK cluster</li>
+ *   <li><strong>Output Monitoring:</strong> Registers output blobs for completion monitoring (if configured)</li>
+ * </ol>
  * <p>
  * TaskSubmitter is an internal implementation class and should not be used directly
  * by client applications. Use {@link SessionHandle} for task submission operations.
+ * <p>
+ * This class is thread-safe and supports concurrent task submissions within the same session.
  *
  * @see SessionHandle#submitTask(TaskDefinition)
  * @see TaskHandle
@@ -75,54 +88,66 @@ final class TaskSubmitter {
   /**
    * Creates a new task submitter for the specified session context.
    * <p>
-   * The task submitter will use the provided session identifier and default task
-   * configuration for all submitted tasks. It will coordinate with the blob completion
-   * listener to handle output processing events.
+   * The task submitter will use the session's configuration for default task settings and
+   * will optionally set up blob completion coordination if an output listener is configured
+   * in the session definition.
    *
-   * @param sessionId the identifier of the session context for task submission
-   * @param taskConfiguration the default configuration to apply to submitted tasks
-   * @param outputTaskListener the listener to receive task output completion events
-   * @param channel the gRPC channel for cluster communication
+   * @param sessionId         the identifier of the session context for task submission
+   * @param sessionDefinition the session definition containing task configuration and output listener
+   * @param channel           the gRPC channel for cluster communication
    * @throws NullPointerException if any parameter is null
-   * @see BlobCompletionListener
+   * @see SessionDefinition
+   * @see BlobCompletionCoordinator
    */
   TaskSubmitter(SessionId sessionId,
-                       TaskConfiguration taskConfiguration,
-                       BlobCompletionListener outputTaskListener,
-                       ManagedChannel channel) {
+                SessionDefinition sessionDefinition,
+                ManagedChannel channel) {
 
     this.sessionId = sessionId;
-    this.defaultTaskConfiguration = taskConfiguration != null ? taskConfiguration : defaultConfiguration();
+    this.defaultTaskConfiguration = sessionDefinition.taskConfiguration() != null ? sessionDefinition.taskConfiguration() : defaultConfiguration();
     this.channel = channel;
     this.resultsFutureStub = newFutureStub(channel);
     this.tasksStub = TasksGrpc.newFutureStub(channel);
 
-    if (outputTaskListener != null) {
-      this.blobCompletionCoordinator = new BlobCompletionCoordinator(channel, outputTaskListener);
+    if (sessionDefinition.outputListener() != null) {
+      this.blobCompletionCoordinator = new BlobCompletionCoordinator(sessionId, channel, sessionDefinition);
     }
   }
 
   /**
    * Submits a task for execution based on the provided task definition.
    * <p>
-   * This method orchestrates the complete task submission process, including:
-   * <ul>
-   *   <li>Allocating blob handles for inputs and outputs</li>
-   *   <li>Uploading input data to the cluster</li>
-   *   <li>Creating the task with proper dependencies</li>
-   *   <li>Registering output completion monitoring</li>
-   * </ul>
-   * The returned handle provides access to task metadata and associated blobs.
+   * This method orchestrates the complete task submission process:
+   * <ol>
+   *   <li><strong>Blob Allocation:</strong> Allocates blob handles for all inputs, outputs, and the task payload</li>
+   *   <li><strong>Data Upload:</strong> Uploads input data content to the allocated blob handles</li>
+   *   <li><strong>Payload Upload:</strong> Creates and uploads a JSON payload containing input/output mappings</li>
+   *   <li><strong>Task Creation:</strong> Submits the task to ArmoniK with proper dependencies</li>
+   *   <li><strong>Output Monitoring:</strong> Registers output blobs with the completion coordinator</li>
+   * </ol>
+   * The returned {@link TaskHandle} provides immediate access to task metadata and blob handles,
+   * while the actual submission continues asynchronously in the background.
+   * <p>
+   * <strong>Task Configuration Priority:</strong> If the task definition specifies a configuration,
+   * it takes precedence over the session's default configuration. Otherwise, the session default applies.
    *
-   * @param taskDefinition the definition specifying task inputs, outputs, and configuration
-   * @return a handle representing the submitted task
+   * @param taskDefinition the definition specifying task inputs, outputs, and optional configuration
+   * @return a handle representing the submitted task with access to inputs, outputs, and metadata
    * @throws NullPointerException if taskDefinition is null
-   * @throws RuntimeException if task submission fails
+   * @throws RuntimeException     if task submission fails due to cluster communication issues,
+   *                              blob allocation failures, or data upload errors
    * @see TaskDefinition
    * @see TaskHandle
+   * @see BlobHandle
    */
-  public TaskHandle submit(TaskDefinition taskDefinition) {
+  TaskHandle submit(TaskDefinition taskDefinition) {
     requireNonNull(taskDefinition, "taskDefinition must not be null");
+    logger.atDebug()
+          .addKeyValue("operation", "submit")
+          .addKeyValue("sessionId", sessionId.asString())
+          .addKeyValue("inputs", taskDefinition.inputDefinitions().size() + taskDefinition.inputHandles().size())
+          .addKeyValue("outputs", taskDefinition.outputs().size())
+          .log("Submitting task");
 
     var allocation = allocateBlobHandles(taskDefinition);
     uploadInputs(allocation, taskDefinition.inputDefinitions());
@@ -131,7 +156,7 @@ final class TaskSubmitter {
     uploadPayload(allInputHandles, allocation);
 
     if (blobCompletionCoordinator != null) {
-      blobCompletionCoordinator.enqueue(sessionId, allocation.outputHandlesByName().values().stream().toList());
+      blobCompletionCoordinator.enqueue(allocation.outputHandlesByName().values().stream().toList());
     }
 
     var inputIdStages = getIdsFrom(allInputHandles.values());
@@ -145,6 +170,23 @@ final class TaskSubmitter {
                                      .thenCompose(request -> toCompletionStage(tasksStub.submitTasks(request)))
                                      .thenApply(response -> new TaskInfo(TaskId.from(response.getTaskInfos(0).getTaskId())));
 
+    deferredTaskInfo.whenComplete((info, ex) -> {
+      if (ex == null) {
+        logger.atDebug()
+              .addKeyValue("operation", "submit")
+              .addKeyValue("sessionId", sessionId.asString())
+              .addKeyValue("taskId", info.id().asString())
+              .log("Task submitted");
+      } else {
+        logger.atError()
+              .addKeyValue("operation", "submit")
+              .addKeyValue("sessionId", sessionId.asString())
+              .addKeyValue("error", ex.getClass().getSimpleName())
+              .setCause(ex)
+              .log("Task submission failed");
+      }
+    });
+
     return new TaskHandle(
       sessionId,
       taskDefinition.configuration() != null ? taskDefinition.configuration() : defaultTaskConfiguration,
@@ -157,14 +199,21 @@ final class TaskSubmitter {
   /**
    * Returns a completion stage that completes when all currently tracked output operations finish.
    * <p>
-   * This method provides access to the underlying blob completion coordinator's
-   * wait functionality, allowing callers to synchronize on output processing completion.
+   * This method provides access to the underlying blob completion coordinator's synchronization
+   * mechanism, allowing callers to wait for all pending output processing to complete. This is
+   * useful for ensuring that all task outputs have been processed before proceeding with
+   * dependent operations.
+   * <p>
+   * If no blob completion coordinator is configured (i.e., any output listener in the session),
+   * this method may return a null completion stage.
    *
-   * @return a completion stage that completes when all current output operations finish
-   * @see BlobCompletionCoordinator#waitUntilFinished()
+   * @return a completion stage that completes when all current output operations finish,
+   * or null if no output coordination is configured
+   * @see BlobCompletionCoordinator#waitUntilIdle()
+   * @see SessionHandle#awaitOutputsProcessed()
    */
-  public CompletionStage<Void> waitUntilFinished() {
-    return blobCompletionCoordinator.waitUntilFinished();
+  CompletionStage<Void> waitUntilFinished() {
+    return blobCompletionCoordinator.waitUntilIdle();
   }
 
   private static BiFunction<AllInputs, List<BlobId>, TaskCreation> toTaskCreation(TaskDefinition taskDefinition) {
@@ -180,6 +229,12 @@ final class TaskSubmitter {
     int inputDefinitionCount = taskDefinition.inputDefinitions().size();
     int outputCount = taskDefinition.outputs().size();
     int totalHandleCount = inputDefinitionCount + outputCount + 1;
+    logger.atTrace()
+          .addKeyValue("operation", "allocateBlobHandles")
+          .addKeyValue("inputs", inputDefinitionCount)
+          .addKeyValue("outputs", outputCount)
+          .addKeyValue("total", totalHandleCount)
+          .log("Requesting blob handles");
 
     var resultRaws = Futures.toCompletionStage(resultsFutureStub.createResultsMetaData(toResultMetaDataRequest(sessionId, totalHandleCount)))
                             .thenApply(CreateResultsMetaDataResponse::getResultsList);
@@ -196,6 +251,10 @@ final class TaskSubmitter {
   }
 
   private void uploadPayload(Map<String, BlobHandle> allInputHandlesByName, BlobHandlesAllocation allocation) {
+    logger.atTrace()
+          .addKeyValue("operation", "uploadPayload")
+          .log("Payload upload initiated");
+
     var inputIdByName = allInputHandlesByName.entrySet().stream().collect(ids());
     var outputIdByName = allocation.outputHandlesByName().entrySet().stream().collect(ids());
 
@@ -205,6 +264,11 @@ final class TaskSubmitter {
   }
 
   private void uploadInputs(BlobHandlesAllocation allocation, Map<String, BlobDefinition> inputDefinitions) {
+    logger.atTrace()
+          .addKeyValue("operation", "uploadInputs")
+          .addKeyValue("count", allocation.inputHandlesByName().size())
+          .log("Input uploads initiated");
+
     allocation.inputHandlesByName()
               .entrySet()
               .stream()
@@ -212,6 +276,48 @@ final class TaskSubmitter {
                 Map.Entry::getValue,
                 entry -> inputDefinitions.get(entry.getKey())))
               .forEach(BlobHandle::uploadData);
+  }
+
+  /**
+   * Internal record representing task inputs after blob ID resolution.
+   * <p>
+   * This record contains the resolved blob identifiers needed for task creation,
+   * combining the payload ID with all input dependencies.
+   *
+   * @param payloadId the blob ID of the task's JSON payload
+   * @param inputIds  the list of blob IDs for all task input dependencies
+   */
+  private record AllInputs(BlobId payloadId, List<BlobId> inputIds) {
+  }
+
+  /**
+   * Internal record representing the allocated blob handles for a task submission.
+   * <p>
+   * This record groups all blob handles allocated during task submission, providing
+   * organized access to payload, input, and output blob handles by their logical names.
+   *
+   * @param payloadHandle       the blob handle for the task's JSON payload containing input/output mappings
+   * @param inputHandlesByName  map of input blob handles keyed by their logical input names
+   * @param outputHandlesByName map of output blob handles keyed by their logical output names
+   * @see #allocateBlobHandles(TaskDefinition)
+   */
+  private record BlobHandlesAllocation(BlobHandle payloadHandle,
+                                       Map<String, BlobHandle> inputHandlesByName,
+                                       Map<String, BlobHandle> outputHandlesByName) {
+  }
+
+  private BlobDefinition serializeToJson(Map<String, BlobId> inputIds, Map<String, BlobId> outputIds) {
+    var in = inputIds.entrySet()
+                     .stream()
+                     .collect(toMap(Map.Entry::getKey, e -> e.getValue().asString()));
+    var out = outputIds.entrySet()
+                       .stream()
+                       .collect(toMap(Map.Entry::getKey, e -> e.getValue().asString()));
+
+    var payload = Map.of("inputs", in, "outputs", out);
+    byte[] bytes = gson.toJson(payload).getBytes(UTF_8);
+
+    return BlobDefinition.from(bytes);
   }
 
   private static Collector<Map.Entry<String, BlobHandle>, ?, Map<String, CompletionStage<BlobId>>> ids() {
@@ -224,16 +330,6 @@ final class TaskSubmitter {
   private static CompletionStage<List<BlobId>> getIdsFrom(Collection<BlobHandle> blobHandles) {
     return Futures.allOf(blobHandles.stream().map(BlobHandle::deferredBlobInfo).toList())
                   .thenApply(blobInfos -> blobInfos.stream().map(BlobInfo::id).toList());
-  }
-
-  private record AllInputs(BlobId payloadId, List<BlobId> inputIds) {
-  }
-
-  public record BlobHandlesAllocation(
-    BlobHandle payloadHandle,
-    Map<String, BlobHandle> inputHandlesByName,
-    Map<String, BlobHandle> outputHandlesByName
-  ) {
   }
 
   private IntFunction<BlobHandle> toBlobHandle(SessionId sessionId, CompletionStage<List<ResultRaw>> resultRaws) {
@@ -256,19 +352,5 @@ final class TaskSubmitter {
       map.put(keyIt.next(), valIt.next());
     }
     return map;
-  }
-
-  public BlobDefinition serializeToJson(Map<String, BlobId> inputIds, Map<String, BlobId> outputIds) {
-    var in = inputIds.entrySet()
-                     .stream()
-                     .collect(toMap(Map.Entry::getKey, e -> e.getValue().asString()));
-    var out = outputIds.entrySet()
-                       .stream()
-                       .collect(toMap(Map.Entry::getKey, e -> e.getValue().asString()));
-
-    var payload = Map.of("inputs", in, "outputs", out);
-    byte[] bytes = gson.toJson(payload).getBytes(UTF_8);
-
-    return BlobDefinition.from(bytes);
   }
 }

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/model/BlobCompletionCoordinatorTest.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/model/BlobCompletionCoordinatorTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.model;
+
+import fr.aneo.armonik.client.testutils.CountingDeterministicScheduler;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static fr.aneo.armonik.client.model.TestDataFactory.blobHandle;
+import static java.time.Duration.ofSeconds;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class BlobCompletionCoordinatorTest {
+
+  private CountingDeterministicScheduler scheduler;
+  private DeterministicScheduler completionScheduler;
+  private BlobCompletionEventWatcher watcher;
+  private AtomicInteger completionSeq;
+
+  @BeforeEach
+  void setUp() {
+    watcher = mock(BlobCompletionEventWatcher.class);
+    scheduler = new CountingDeterministicScheduler();
+    completionScheduler = new CountingDeterministicScheduler();
+    completionSeq = new AtomicInteger(0);
+    when(watcher.watch(anyList())).thenAnswer(inv -> {
+      var f = new CompletableFuture<Void>();
+      int delaySeconds = completionSeq.incrementAndGet();
+      completionScheduler.schedule(() -> { f.complete(null); }, delaySeconds, SECONDS);
+      return f;
+    });
+  }
+
+  @Test
+  void should_flush_immediately_when_batch_size_threshold_is_reached() {
+    // Given
+    var policy = new BatchingPolicy(3, ofSeconds(10), 2, 100);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    coordinator.enqueue(blobHandles(3));
+
+    // Then
+    verify(watcher).watch(argThat(handles -> handles.size() == 3));
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_flush_when_timer_expires_and_batch_size_not_reached() {
+    // Given
+    var policy = new BatchingPolicy(10, ofSeconds(1), 2, 100);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    coordinator.enqueue(blobHandles(2));
+
+    // Then
+    verify(watcher, never()).watch(anyList());
+
+    // And
+    scheduler.tick(1, SECONDS);
+    verify(watcher).watch(argThat(handles -> handles.size() == 2));
+    assertThat(scheduler.scheduleCount()).isEqualTo(1);
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_aggregate_multiple_enqueues_into_single_batch_when_timer_fires() {
+    // Given
+    var policy = new BatchingPolicy(10, ofSeconds(1), 2, 100);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    coordinator.enqueue(blobHandles(1));
+    coordinator.enqueue(blobHandles(1));
+
+    // Then
+    verify(watcher, never()).watch(anyList());
+
+    // And
+    scheduler.tick(1, SECONDS);
+    verify(watcher).watch(argThat(handles -> handles.size() == 2));
+    assertThat(scheduler.scheduleCount()).isEqualTo(1);
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_cancel_timer_after_size_triggered_flush_and_not_fire_later() {
+    // Given
+    var policy = new BatchingPolicy(3, ofSeconds(1), 2, 100);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    coordinator.enqueue(blobHandles(3));
+
+    // Then
+    verify(watcher).watch(argThat(handles -> handles.size() == 3));
+
+    // And
+    scheduler.tick(1, SECONDS);
+    verify(watcher).watch(anyList());
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_rearm_timer_for_new_epoch_after_flush() {
+    // Given
+    var policy = new BatchingPolicy(10, ofSeconds(1), 2, 100);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    coordinator.enqueue(blobHandles(2));
+    assertThat(scheduler.scheduleCount()).isEqualTo(1);
+    scheduler.tick(1, SECONDS);
+
+    // Then
+    verify(watcher).watch(argThat(handles -> handles.size() == 2));
+
+    // And
+    coordinator.enqueue(blobHandles(1));
+    assertThat(scheduler.scheduleCount()).isEqualTo(2);
+    scheduler.tick(1, SECONDS);
+    verify(watcher).watch(argThat(handles -> handles.size() == 1));
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_split_batch_by_cap_on_size_triggered_flush() {
+    // Given
+    var policy = new BatchingPolicy(1, ofSeconds(10), 2, 3);
+    when(watcher.watch(anyList())).thenReturn(completedFuture(null));
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    coordinator.enqueue(blobHandles(7));
+
+    // Then
+    var captor = blobHandlesCaptor();
+    verify(watcher, times(3)).watch(captor.capture());
+
+    var sizes = captor.getAllValues().stream().map(List::size).toList();
+    assertThat(sizes).containsExactly(3, 3, 1);
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_split_batch_by_cap_on_timer_flush() {
+    // Given
+    var policy = new BatchingPolicy(1000, ofSeconds(1), 2, 3);
+    when(watcher.watch(anyList())).thenReturn(completedFuture(null));
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    coordinator.enqueue(blobHandles(7));
+    verify(watcher, never()).watch(anyList());
+    scheduler.tick(1, SECONDS);
+
+    // Then
+    var captor = blobHandlesCaptor();
+    verify(watcher, times(3)).watch(captor.capture());
+
+    var sizes = captor.getAllValues().stream().map(List::size).toList();
+    assertThat(sizes).containsExactly(3, 3, 1);
+    assertThat(scheduler.scheduleCount()).isEqualTo(1);
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_not_exceed_max_concurrent_batches() {
+    // Given
+    var policy = new BatchingPolicy(1, ofSeconds(10), 2, 100);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    coordinator.enqueue(blobHandles(1));
+    coordinator.enqueue(blobHandles(1));
+    coordinator.enqueue(blobHandles(1));
+
+    // Then
+    verify(watcher, times(2)).watch(anyList());
+
+    // And when: frees one slot
+    completionScheduler.tick(1, SECONDS);
+
+    // Then: third call should start
+    verify(watcher, times(3)).watch(anyList());
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_accumulate_while_saturated_and_flush_on_completion_respecting_cap() {
+    // Given
+    var policy = new BatchingPolicy(1, ofSeconds(10), 2, 3);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    coordinator.enqueue(blobHandles(1));
+    coordinator.enqueue(blobHandles(1));
+
+    // When
+    coordinator.enqueue(blobHandles(5));
+
+    // Then
+    verify(watcher, times(2)).watch(anyList());
+
+    // And when: complete one running call to free a slot
+    completionScheduler.tick(1, SECONDS);
+
+    // Then
+    var captor = blobHandlesCaptor();
+    verify(watcher, times(3)).watch(captor.capture());
+    assertThat(captor.getValue().size()).isEqualTo(3);
+
+    // And when: completes the second running call
+    completionScheduler.tick(1, SECONDS);
+
+    // Then: remaining 2 should flush in one more call
+    verify(watcher, times(4)).watch(captor.capture());
+    assertThat(captor.getValue().size()).isEqualTo(2);
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void should_not_dispatch_on_timer_while_saturated() {
+    // Given
+    var policy = new BatchingPolicy(1, ofSeconds(1), 2, 3);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    coordinator.enqueue(blobHandles(1));
+    coordinator.enqueue(blobHandles(1));
+
+    // When
+    coordinator.enqueue(blobHandles(5));
+
+    // Then: still only 2 calls running so far
+    verify(watcher, times(2)).watch(anyList());
+
+    // And When: even if the timer expires while saturated
+    scheduler.tick(1, SECONDS);
+
+    // Then: no additional dispatch should occur due to saturation
+    verify(watcher, times(2)).watch(anyList());
+
+    // And When: a slot frees up
+    completionScheduler.tick(1, SECONDS);
+
+    // Then: exactly one new call starts
+    var captor = blobHandlesCaptor();
+    verify(watcher, times(3)).watch(captor.capture());
+    assertThat(captor.getValue().size()).isEqualTo(3);
+
+    // Cleanup
+    completeAllAndAwait(coordinator);
+  }
+
+  @Test
+  void waitUntilIdle_should_drain_buffer_and_inflight() {
+    // Given
+    var policy = new BatchingPolicy(1, ofSeconds(10), 1, 3);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+    coordinator.enqueue(blobHandles(7));
+
+    // When
+    var idle = coordinator.waitUntilIdle();
+    completionScheduler.tick(1, DAYS);
+    completionScheduler.runUntilIdle();
+
+    // Then
+    assertThat(idle.toCompletableFuture()).isCompleted();
+  }
+
+  @Test
+  void waitUntilIdle_should_complete_successfully_even_if_some_batches_fail() {
+    // Given
+    var policy = new BatchingPolicy(1, ofSeconds(10), 1, 3);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+    var callIdx = new AtomicInteger(0);
+    when(watcher.watch(anyList())).thenAnswer(inv -> {
+      var f = new CompletableFuture<Void>();
+      int i = callIdx.getAndIncrement();
+      if (i == 0) {
+        completionScheduler.schedule(() -> f.completeExceptionally(new RuntimeException("boom")), 1, SECONDS);
+      } else {
+        completionScheduler.schedule(() -> f.complete(null), 2, SECONDS);
+      }
+      return f;
+    });
+    coordinator.enqueue(blobHandles(4));
+
+    // When
+    var idle = coordinator.waitUntilIdle();
+    completionScheduler.tick(1, DAYS);
+    completionScheduler.runUntilIdle();
+
+    // Then
+    assertThat(idle.toCompletableFuture()).isCompleted();
+  }
+
+  @Test
+  void waitUntilIdle_should_return_immediately_when_no_work() {
+    // Given
+    var policy = new BatchingPolicy(1, ofSeconds(10), 1, 3);
+    var coordinator = new BlobCompletionCoordinator(watcher, policy, scheduler);
+
+    // When
+    var idle = coordinator.waitUntilIdle();
+
+    // Then
+    assertThat(idle.toCompletableFuture()).isCompleted();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ArgumentCaptor<List<BlobHandle>> blobHandlesCaptor() {
+    return ArgumentCaptor.forClass(List.class);
+  }
+
+  private static List<BlobHandle> blobHandles(int n) {
+    return IntStream.range(0, n)
+                    .mapToObj(i -> blobHandle("sessionId", "blobId-" + i))
+                    .toList();
+  }
+
+  private void completeAllAndAwait(BlobCompletionCoordinator coordinator) {
+    completionScheduler.tick(1, DAYS);
+    completionScheduler.runUntilIdle();
+    coordinator.waitUntilIdle().toCompletableFuture().join();
+  }
+}

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/model/BlobCompletionEventWatcherTest.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/model/BlobCompletionEventWatcherTest.java
@@ -50,109 +50,114 @@ class BlobCompletionEventWatcherTest extends InProcessGrpcTestBase {
     blobInfo = blobInfo("BlobId");
     blobHandle = new BlobHandle(sessionId, completedFuture(blobInfo), channel);
     resultsGrpcMock.reset();
-    blobCompletionEventWatcher = new BlobCompletionEventWatcher(channel);
   }
 
 
   @Test
   void should_call_observer_on_success_when_blob_update_status_is_completed() {
     // Given
-    var observerMock = new BlobCompletionListenerMock();
+    var listenerMock = new BlobCompletionListenerMock();
+    blobCompletionEventWatcher = new BlobCompletionEventWatcher(sessionId, channel, listenerMock);
     resultsGrpcMock.setDownloadContentFor(blobId("BlobId"), "Hello World !!".getBytes(UTF_8));
 
     // when
-    var done = blobCompletionEventWatcher.watch(sessionId, List.of(blobHandle), observerMock);
+    var done = blobCompletionEventWatcher.watch(List.of(blobHandle));
     eventsGrpcMock.emitStatusUpdate(blobInfo.id(), RESULT_STATUS_COMPLETED);
     eventsGrpcMock.complete();
     done.toCompletableFuture().join();
 
     // then
-    assertThat(observerMock.blobErrors).isEmpty();
-    assertThat(observerMock.blobs).hasSize(1);
-    Assertions.assertThat(observerMock.blobs.get(0).data()).isEqualTo("Hello World !!".getBytes(UTF_8));
-    Assertions.assertThat(observerMock.blobs.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
+    assertThat(listenerMock.blobErrors).isEmpty();
+    assertThat(listenerMock.blobs).hasSize(1);
+    Assertions.assertThat(listenerMock.blobs.get(0).data()).isEqualTo("Hello World !!".getBytes(UTF_8));
+    Assertions.assertThat(listenerMock.blobs.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
   }
 
   @Test
   void should_call_observer_on_error_when_blob_update_status_is_aborted() {
     // Given
-    var observerMock = new BlobCompletionListenerMock();
+    var listenerMock = new BlobCompletionListenerMock();
+    blobCompletionEventWatcher = new BlobCompletionEventWatcher(sessionId, channel, listenerMock);
 
 
     // when
-    var done = blobCompletionEventWatcher.watch(sessionId, List.of(blobHandle), observerMock);
+    var done = blobCompletionEventWatcher.watch(List.of(blobHandle));
     eventsGrpcMock.emitStatusUpdate(blobInfo.id(), RESULT_STATUS_ABORTED);
     eventsGrpcMock.complete();
     done.toCompletableFuture().join();
 
     // then
-    assertThat(observerMock.blobs).isEmpty();
-    assertThat(observerMock.blobErrors).hasSize(1);
-    Assertions.assertThat(observerMock.blobErrors.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
+    assertThat(listenerMock.blobs).isEmpty();
+    assertThat(listenerMock.blobErrors).hasSize(1);
+    Assertions.assertThat(listenerMock.blobErrors.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
   }
 
   @Test
   void should_call_observer_on_success_when_new_blob_status_is_completed() {
     // Given
-    var observerMock = new BlobCompletionListenerMock();
+    var listenerMock = new BlobCompletionListenerMock();
+    blobCompletionEventWatcher = new BlobCompletionEventWatcher(sessionId, channel, listenerMock);
     resultsGrpcMock.setDownloadContentFor(blobInfo.id(), "Hello World !!".getBytes(UTF_8));
 
     // when
-    var done = blobCompletionEventWatcher.watch(sessionId, List.of(blobHandle), observerMock);
+    var done = blobCompletionEventWatcher.watch(List.of(blobHandle));
     eventsGrpcMock.emitNewResult(blobInfo.id(), RESULT_STATUS_COMPLETED);
     eventsGrpcMock.complete();
     done.toCompletableFuture().join();
 
     // then
-    assertThat(observerMock.blobErrors).isEmpty();
-    assertThat(observerMock.blobs).hasSize(1);
-    Assertions.assertThat(observerMock.blobs.get(0).data()).isEqualTo("Hello World !!".getBytes(UTF_8));
-    Assertions.assertThat(observerMock.blobs.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
+    assertThat(listenerMock.blobErrors).isEmpty();
+    assertThat(listenerMock.blobs).hasSize(1);
+    Assertions.assertThat(listenerMock.blobs.get(0).data()).isEqualTo("Hello World !!".getBytes(UTF_8));
+    Assertions.assertThat(listenerMock.blobs.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
   }
 
   @Test
   void should_call_observer_on_error_when_new_blob_update_status_is_aborted() {
     // Given
-    var observerMock = new BlobCompletionListenerMock();
+    var listenerMock = new BlobCompletionListenerMock();
+    blobCompletionEventWatcher = new BlobCompletionEventWatcher(sessionId, channel, listenerMock);
 
     // when
-    var done = blobCompletionEventWatcher.watch(sessionId, List.of(blobHandle), observerMock);
+    var done = blobCompletionEventWatcher.watch(List.of(blobHandle));
     eventsGrpcMock.emitNewResult(blobInfo.id(), RESULT_STATUS_ABORTED);
     eventsGrpcMock.complete();
     done.toCompletableFuture().join();
 
     // then
-    assertThat(observerMock.blobs).isEmpty();
-    assertThat(observerMock.blobErrors).hasSize(1);
-    Assertions.assertThat(observerMock.blobErrors.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
+    assertThat(listenerMock.blobs).isEmpty();
+    assertThat(listenerMock.blobErrors).hasSize(1);
+    Assertions.assertThat(listenerMock.blobErrors.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
   }
 
   @Test
   void should_call_observer_on_error_when_downloading_blob_failed() {
     // Given
-    var completionListenerMock = new BlobCompletionListenerMock();
+    var listenerMock = new BlobCompletionListenerMock();
+    blobCompletionEventWatcher = new BlobCompletionEventWatcher(sessionId, channel, listenerMock);
     resultsGrpcMock.failDownloadFor(blobInfo.id());
 
     // when
-    var done = blobCompletionEventWatcher.watch(sessionId, List.of(blobHandle), completionListenerMock);
+    var done = blobCompletionEventWatcher.watch(List.of(blobHandle));
     eventsGrpcMock.emitNewResult(blobInfo.id(), RESULT_STATUS_COMPLETED);
     eventsGrpcMock.complete();
     done.toCompletableFuture().join();
 
     // then
-    assertThat(completionListenerMock.blobs).isEmpty();
-    assertThat(completionListenerMock.blobErrors).hasSize(1);
-    Assertions.assertThat(completionListenerMock.blobErrors.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
+    assertThat(listenerMock.blobs).isEmpty();
+    assertThat(listenerMock.blobErrors).hasSize(1);
+    Assertions.assertThat(listenerMock.blobErrors.get(0).blobInfo().id()).isEqualTo(blobInfo.id());
   }
 
   @Test
   void should_complete_even_if_blob_listener_throws_on_success() {
     // Given
     var failingListenerMock = new FailingListenerMock();
+    blobCompletionEventWatcher = new BlobCompletionEventWatcher(sessionId, channel, failingListenerMock);
     resultsGrpcMock.setDownloadContentFor(blobInfo.id(), "OK".getBytes(UTF_8));
 
     // When
-    var done = blobCompletionEventWatcher.watch(sessionId, List.of(blobHandle), failingListenerMock);
+    var done = blobCompletionEventWatcher.watch(List.of(blobHandle));
     eventsGrpcMock.emitNewResult(blobInfo.id(), RESULT_STATUS_COMPLETED);
     eventsGrpcMock.complete();
 
@@ -168,9 +173,10 @@ class BlobCompletionEventWatcherTest extends InProcessGrpcTestBase {
   void should_complete_even_if_blob_listener_throws_on_error() {
     // Given
     var failingListenerMock = new FailingListenerMock();
+    blobCompletionEventWatcher = new BlobCompletionEventWatcher(sessionId, channel, failingListenerMock);
 
     // When
-    var done = blobCompletionEventWatcher.watch(sessionId, List.of(blobHandle), failingListenerMock);
+    var done = blobCompletionEventWatcher.watch(List.of(blobHandle));
     eventsGrpcMock.emitNewResult(blobInfo.id(), RESULT_STATUS_ABORTED);
     eventsGrpcMock.complete();
 

--- a/armonik-client/src/test/java/fr/aneo/armonik/client/testutils/CountingDeterministicScheduler.java
+++ b/armonik-client/src/test/java/fr/aneo/armonik/client/testutils/CountingDeterministicScheduler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2025 ANEO (armonik@aneo.fr)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.aneo.armonik.client.testutils;
+
+import org.jmock.lib.concurrent.DeterministicScheduler;
+
+import java.util.concurrent.*;
+
+public final class CountingDeterministicScheduler extends DeterministicScheduler {
+  private int scheduleCount;
+
+  public int scheduleCount() { return scheduleCount; }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    scheduleCount++;
+    return super.schedule(command, delay, unit);
+  }
+}

--- a/armonik-client/src/test/resources/logback.xml
+++ b/armonik-client/src/test/resources/logback.xml
@@ -1,25 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
-
-  <property name="CONSOLE_LOG_PATTERN"
-            value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m %kvp%n%ex"/>
-
-  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg %xEx{5}%n</pattern>
     </encoder>
   </appender>
 
-  <logger name="fr.aneo.armonik.client" level="INFO" additivity="false">
-    <appender-ref ref="CONSOLE"/>
-  </logger>
-
-  <logger name="fr.aneo.armonik.client.blob" level="DEBUG" additivity="false">
-    <appender-ref ref="CONSOLE"/>
-  </logger>
-
-  <root level="WARN">
-    <appender-ref ref="CONSOLE"/>
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
   </root>
 </configuration>


### PR DESCRIPTION
# Motivation

The existing `BlobCompletionCoordinator` implementation was minimal and lacked support for batching, concurrency, and proper coordination of blob completion events. 

# Description

This PR introduces a full rework of the `BlobCompletionCoordinator`:

- Added **batching support** with configurable batch size, max delay, and per-call cap.
- Implemented **parallelism control** via a configurable `maxConcurrentBatches`, backed by a `Semaphore`.
- Introduced **drain pattern** and `pushBackFront` to handle re-buffering when no permits are available.
- Added a new `waitUntilIdle()` method, allowing clients to flush pending work and await until both buffer and in-flight batches are empty. This method always completes successfully, leaving error handling to callers.
- Resend leftover blob handles after watch completes
- Extended **structured logging (SLF4J)** across coordinator lifecycle:
  - `enqueue`, `flush`, `dispatch`, `timer`, `completion`, and `idle` states.
- Comprehensive **JUnit 5 test suite** with deterministic scheduler:
  - Validates batching by size, by time, and by cap.
  - Covers parallel saturation, accumulation while saturated, and idle waiting.
  - Ensures robustness for both successful and failing watcher completions.


# Testing

- Added unit tests for all batching and concurrency scenarios using a deterministic scheduler for reproducibility.
- Verified correctness of idle waiting semantics (`waitUntilIdle()`).
- Validated structured logs appear as expected during enqueue/flush/dispatch phases.
- CI runs all tests successfully.

# Impact

- Provides fine-grained control over batching and concurrency in the ArmoniK client.
- Improves observability with trace/debug logs, making debugging easier under load.
- No breaking changes to existing APIs outside of the coordinator internals.
- Slight performance improvement through better batching and avoidance of excessive calls when saturated.

# Additional Information

- This PR sets the foundation for handling **remaining pending blob handles** (planned in a future feature).
- Default batching policies remain configurable and can be tuned without code changes.