### PR TITLE
feat: add support for session-scoped blobs

### DIFF
--- a/armonik-client/src/main/java/fr/aneo/armonik/client/model/BlobHandle.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/model/BlobHandle.java
@@ -36,6 +36,13 @@ import static java.util.Objects.requireNonNull;
  * provides a lightweight reference to blob data stored in the ArmoniK cluster and offers
  * direct upload and download capabilities through gRPC interactions.
  * <p>
+ * BlobHandles can be created in two ways:
+ * <ul>
+ *   <li><strong>Task-specific blobs:</strong> Created automatically during task submission for inputs and outputs</li>
+ *   <li><strong>Session-scoped blobs:</strong> Created explicitly via {@link SessionHandle#createBlob(BlobDefinition)}
+ *       for sharing across multiple tasks within the same session</li>
+ * </ul>
+ * <p>
  * BlobHandle instances are responsible for managing their own data lifecycle, including:
  * <ul>
  *   <li>Uploading data content to the cluster</li>
@@ -50,7 +57,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see BlobInfo
  * @see BlobDefinition
- * @see SessionHandle
+ * @see SessionHandle#createBlob(BlobDefinition)
  * @see TaskHandle
  */
 public final class BlobHandle {
@@ -85,7 +92,7 @@ public final class BlobHandle {
    */
   BlobHandle(SessionId sessionId, CompletionStage<BlobInfo> deferredBlobInfo, ManagedChannel channel) {
     requireNonNull(sessionId, "sessionId must not be null");
-    requireNonNull(deferredBlobInfo, "blobInfo");
+    requireNonNull(deferredBlobInfo, "deferredBlobInfo must no be null");
     requireNonNull(channel, "chanel must not be null");
 
     this.sessionId = sessionId;

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/model/BlobId.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/model/BlobId.java
@@ -17,6 +17,8 @@ package fr.aneo.armonik.client.model;
 
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Immutable identifier for a blob within the ArmoniK distributed computing platform.
  * <p>
@@ -29,7 +31,7 @@ import java.util.Objects;
  * @see BlobInfo
  * @see BlobHandle
  */
-public class BlobId {
+public final class BlobId {
   private final String id;
 
   private BlobId(String id) {
@@ -56,6 +58,8 @@ public class BlobId {
    * @throws NullPointerException if id is null
    */
   static BlobId from(String id) {
+    requireNonNull(id, "id must not be null");
+    if (id.isBlank()) throw  new IllegalArgumentException("id must not be blank");
     return new BlobId(id);
   }
 

--- a/armonik-client/src/main/java/fr/aneo/armonik/client/model/BlobInfo.java
+++ b/armonik-client/src/main/java/fr/aneo/armonik/client/model/BlobInfo.java
@@ -17,6 +17,8 @@ package fr.aneo.armonik.client.model;
 
 import java.util.Objects;
 
+import static java.util.Objects.*;
+
 /**
  * Immutable metadata describing a blob within the ArmoniK distributed computing platform.
  * <p>
@@ -36,7 +38,7 @@ public final class BlobInfo {
    *
    */
    BlobInfo(BlobId id) {
-    this.id = id;
+     this.id = requireNonNull(id, "id must not be null");
   }
 
   public BlobId id() {


### PR DESCRIPTION
# Motivation

This change introduces session-scoped blob functionality to the ArmoniK Java client, enabling efficient sharing of blob data across multiple tasks within the same session. Previously, blobs could only be created as task-specific inputs/outputs, leading to potential data duplication when the same content was needed by multiple tasks.

# Description

This PR adds the ability to create session-scoped blobs through a new `createBlob(BlobDefinition)` method in `SessionHandle`. The implementation includes:

The session-scoped blobs are immediately allocated in the ArmoniK cluster with data uploaded asynchronously in the background, allowing them to be referenced by task definitions even while upload is in progress.

# Impact

**Performance Benefits:**
- Reduces duplicate uploads when the same data is needed by multiple tasks
- Improves network efficiency by enabling data reuse across task boundaries

**API Enhancements:**
- Introduces a new public method `SessionHandle.createBlob(BlobDefinition)` for creating shared blobs
- Maintains full backward compatibility with existing task-specific blob workflows
- Enhanced documentation provides clearer guidance on when to use each blob creation approach

**Code Quality:**
- Improved validation and error handling in core blob classes
- Better encapsulation with final classes where appropriate
- More comprehensive JavaDoc documentation

**No Breaking Changes:**
- All existing functionality remains unchanged
- New functionality is purely additive
