### PR TITLE
fix(worker): remove NOT_SERVING status during task processing

### DIFF
--- a/worker/armonik-worker/src/main/java/fr/aneo/armonik/worker/internal/TaskProcessingService.java
+++ b/worker/armonik-worker/src/main/java/fr/aneo/armonik/worker/internal/TaskProcessingService.java
@@ -16,7 +16,6 @@
 package fr.aneo.armonik.worker.internal;
 
 import fr.aneo.armonik.api.grpc.v1.Objects.Output.Error;
-import fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.HealthCheckReply.ServingStatus;
 import fr.aneo.armonik.api.grpc.v1.worker.WorkerGrpc.WorkerImplBase;
 import fr.aneo.armonik.worker.ArmoniKWorker;
 import fr.aneo.armonik.worker.TaskContextFactory;
@@ -31,13 +30,11 @@ import org.slf4j.MDC;
 
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static fr.aneo.armonik.api.grpc.v1.Objects.Empty;
 import static fr.aneo.armonik.api.grpc.v1.Objects.Output;
 import static fr.aneo.armonik.api.grpc.v1.agent.AgentGrpc.AgentFutureStub;
 import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.*;
-import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.HealthCheckReply.ServingStatus.NOT_SERVING;
 import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.HealthCheckReply.ServingStatus.SERVING;
 
 /**
@@ -68,16 +65,6 @@ import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.HealthCheckReply.S
  *         Output/Error
  * </pre>
  *
- * <h2>Health Check Behavior</h2>
- * <p>
- * The Worker reports its serving status through the {@link #healthCheck(Empty, StreamObserver)} method:
- * <ul>
- *   <li>{@link ServingStatus#SERVING}: Worker is idle and ready to accept tasks</li>
- *   <li>{@link ServingStatus#NOT_SERVING}: Worker is currently processing a task</li>
- * </ul>
- * <p>
- * The Agent uses this status to determine whether to assign new tasks to the Worker.
- *
  * <h2>Exception Handling Strategy</h2>
  * <p>
  * Any exception thrown during task processing is caught and handled as follows:
@@ -85,7 +72,6 @@ import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.HealthCheckReply.S
  *   <li>The exception message is extracted (or {@code toString()} if message is {@code null})</li>
  *   <li>A {@link TaskOutcome.Error} is created with the exception message</li>
  *   <li>The error is converted to a gRPC {@link Output} message</li>
- *   <li>The Worker's status is restored to {@link ServingStatus#SERVING}</li>
  *   <li>The response is sent back to the Agent</li>
  * </ol>
  * <p>
@@ -109,7 +95,6 @@ public class TaskProcessingService extends WorkerImplBase {
   private final TaskProcessor taskProcessor;
   private final TaskContextFactory taskContextFactory;
   private final DynamicTaskProcessorLoader dynamicTaskProcessorLoader;
-  final AtomicReference<ServingStatus> servingStatus;
 
   private volatile LoadedTaskProcessor currentLoadedProcessor;
 
@@ -122,7 +107,6 @@ public class TaskProcessingService extends WorkerImplBase {
     this.taskProcessor = taskProcessor;
     this.taskContextFactory = taskContextFactory;
     this.dynamicTaskProcessorLoader = processorLoader;
-    this.servingStatus = new AtomicReference<>(SERVING);
   }
 
   TaskProcessingService(AgentFutureStub agentStub, TaskProcessor taskProcessor, TaskContextFactory taskContextFactory) {
@@ -136,12 +120,10 @@ public class TaskProcessingService extends WorkerImplBase {
    * It orchestrates the complete task processing lifecycle:
    * </p>
    * <ol>
-   *   <li>Sets serving status to {@link ServingStatus#NOT_SERVING}</li>
    *   <li>Creates a {@link TaskContext} using the factory</li>
    *   <li>Invokes the {@link TaskProcessor} with the context</li>
    *   <li>Converts the {@link TaskOutcome} to a gRPC {@link Output}</li>
    *   <li>Sends the response to the Agent</li>
-   *   <li>Restores serving status to {@link ServingStatus#SERVING}</li>
    * </ol>
    *
    * <h4>Exception Handling</h4>
@@ -155,12 +137,6 @@ public class TaskProcessingService extends WorkerImplBase {
    *   <li>The error is sent to the Agent as a normal response (not a gRPC error)</li>
    * </ul>
    *
-   * <h4>Status Updates</h4>
-   * <p>
-   * The serving status is guaranteed to be restored to {@link ServingStatus#SERVING} even if
-   * an exception occurs.
-   * </p>
-   *
    * @param request          the task processing request from the Agent containing task metadata,
    *                         payload, data dependencies, and expected outputs; never {@code null}
    * @param responseObserver the gRPC response observer for sending the processing result
@@ -172,7 +148,6 @@ public class TaskProcessingService extends WorkerImplBase {
     MDC.put("sessionId", request.getSessionId());
 
     long startTime = System.nanoTime();
-    servingStatus.set(NOT_SERVING);
 
     try {
       var workerLibrary = WorkerLibrary.from(request.getTaskOptions().getOptionsMap());
@@ -215,7 +190,6 @@ public class TaskProcessingService extends WorkerImplBase {
                                           .build());
     } finally {
       cleanupDynamicTaskProcessor();
-      servingStatus.set(SERVING);
       responseObserver.onCompleted();
       MDC.clear();
     }
@@ -229,25 +203,6 @@ public class TaskProcessingService extends WorkerImplBase {
    * and determine whether the Worker is ready to accept new tasks.
    * </p>
    *
-   * <h4>Serving Status</h4>
-   * <p>
-   * The returned status indicates:
-   * </p>
-   * <ul>
-   *   <li>{@link ServingStatus#SERVING}: Worker is idle and can accept a new task</li>
-   *   <li>{@link ServingStatus#NOT_SERVING}: Worker is busy processing a task</li>
-   * </ul>
-   *
-   * <h4>Agent Behavior</h4>
-   * <p>
-   * The Agent uses this status to:
-   * </p>
-   * <ul>
-   *   <li>Verify the Worker is alive before assigning tasks</li>
-   *   <li>Avoid sending tasks to busy Workers</li>
-   *   <li>Detect and restart unresponsive Workers</li>
-   * </ul>
-   *
    * @param request          empty request (health checks have no parameters)
    * @param responseObserver the gRPC response observer for sending the health status
    *                         back to the Agent; never {@code null}
@@ -255,7 +210,7 @@ public class TaskProcessingService extends WorkerImplBase {
   @Override
   public void healthCheck(Empty request, StreamObserver<HealthCheckReply> responseObserver) {
     responseObserver.onNext(HealthCheckReply.newBuilder()
-                                            .setStatus(servingStatus.get())
+                                            .setStatus(SERVING)
                                             .build());
     responseObserver.onCompleted();
   }

--- a/worker/armonik-worker/src/test/java/fr/aneo/armonik/worker/internal/TaskProcessingServiceTest.java
+++ b/worker/armonik-worker/src/test/java/fr/aneo/armonik/worker/internal/TaskProcessingServiceTest.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 
 import static fr.aneo.armonik.api.grpc.v1.Objects.Empty;
-import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.HealthCheckReply.ServingStatus.NOT_SERVING;
 import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.HealthCheckReply.ServingStatus.SERVING;
 import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.ProcessReply;
 import static fr.aneo.armonik.api.grpc.v1.worker.WorkerCommon.ProcessRequest;
@@ -158,42 +157,6 @@ class TaskProcessingServiceTest {
   }
 
   @Test
-  @DisplayName("should report NOT_SERVING while process() is running")
-  void should_report_not_serving_while_process_is_running() throws Exception {
-    // Given
-    var processObserver = (StreamObserver<ProcessReply>) mock(StreamObserver.class);
-    var request = ProcessRequest.newBuilder().build();
-    var processingStarted = new CountDownLatch(1);
-    var allowCompletion = new CountDownLatch(1);
-    when(taskProcessor.processTask(taskContext)).thenAnswer(invocation -> {
-      processingStarted.countDown();
-      allowCompletion.await(2, SECONDS);
-      return SUCCESS;
-    });
-    taskProcessingService = new TaskProcessingService(agentStub, taskProcessor, (a, r) -> taskContext);
-    var processingThread = new Thread(() -> taskProcessingService.process(request, processObserver));
-    processingThread.start();
-    processingStarted.await(1, SECONDS);
-
-    // When
-    var healthCheckObserver = (StreamObserver<HealthCheckReply>) mock(StreamObserver.class);
-    taskProcessingService.healthCheck(Empty.getDefaultInstance(), healthCheckObserver);
-
-    // Then: Health check should report NOT_SERVING
-    var replyCap = ArgumentCaptor.forClass(HealthCheckReply.class);
-    var inOrder = inOrder(healthCheckObserver);
-    inOrder.verify(healthCheckObserver).onNext(replyCap.capture());
-    inOrder.verify(healthCheckObserver).onCompleted();
-    inOrder.verifyNoMoreInteractions();
-
-    assertThat(replyCap.getValue().getStatus()).isEqualTo(NOT_SERVING);
-
-    // Cleanup
-    allowCompletion.countDown();
-    processingThread.join(2000);
-  }
-
-  @Test
   @DisplayName("should report SERVING after process() completes")
   void should_report_serving_after_process_completes() {
     // Given: Normal task processing
@@ -266,40 +229,6 @@ class TaskProcessingServiceTest {
     assertThat(reply.getOutput().hasError()).isTrue();
   }
 
-
-  @Test
-  @DisplayName("should remain NOT_SERVING during awaitCompletion")
-  void should_remain_not_serving_during_await_completion() throws Exception {
-    // Given
-    var awaitCompletionStarted = new CountDownLatch(1);
-    var allowAwaitCompletion = new CountDownLatch(1);
-    when(taskProcessor.processTask(taskContext)).thenReturn(SUCCESS);
-    doAnswer(invocation -> {
-      awaitCompletionStarted.countDown();
-      allowAwaitCompletion.await(2, SECONDS);
-      return null;
-    }).when(taskContext).awaitCompletion();
-    taskProcessingService = new TaskProcessingService(agentStub, taskProcessor, (a, r) -> taskContext);
-    var observer = (StreamObserver<ProcessReply>) mock(StreamObserver.class);
-    var request = ProcessRequest.newBuilder().build();
-
-    // When
-    var processingThread = new Thread(() -> taskProcessingService.process(request, observer));
-    processingThread.start();
-
-    // Wait for awaitCompletion to be called
-    awaitCompletionStarted.await(1, SECONDS);
-
-    // Then: Should still be NOT_SERVING during awaitCompletion
-    assertThat(taskProcessingService.servingStatus.get()).isEqualTo(NOT_SERVING);
-
-    // When: Allow awaitCompletion to finish
-    allowAwaitCompletion.countDown();
-    processingThread.join(2000);
-
-    // Then: Should now be SERVING
-    assertThat(taskProcessingService.servingStatus.get()).isEqualTo(SERVING);
-  }
 
   @Test
   @DisplayName("should NOT call awaitCompletion when processTask throws exception")


### PR DESCRIPTION
## Motivation

The worker was reporting `NOT_SERVING` to the Agent while a task was being executed. This is incorrect — the worker should always report `SERVING` so the Agent can correctly monitor its liveness.

## Description

- Removed the `AtomicReference<ServingStatus> servingStatus` field from `TaskProcessingService`
- Removed `servingStatus.set(NOT_SERVING)` at the start of `process()` and `servingStatus.set(SERVING)` from the `finally` block
- `healthCheck()` now always returns `SERVING` directly
- Dropped the `NOT_SERVING` static import and `ServingStatus` type import from both the service and test files
- Removed two tests that asserted the (now-removed) `NOT_SERVING` behaviour: `should_report_not_serving_while_process_is_running` and `should_remain_not_serving_during_await_completion`
- Cleaned up stale Javadoc sections that described the status-toggle behaviour

## Testing

Existing test suite (75 tests) passes. The two deleted tests were specifically asserting the `NOT_SERVING` behaviour that has been removed by design.

## Impact

- Health checks will always return `SERVING` regardless of whether a task is in progress
- No configuration or API changes

## Additional Information

None.